### PR TITLE
Feature/hu p 21 loginadmin

### DIFF
--- a/infra/aws/terraform/main.tf
+++ b/infra/aws/terraform/main.tf
@@ -242,6 +242,14 @@ resource "aws_vpc_security_group_ingress_rule" "ecs_tasks_from_public_alb_8080" 
   ip_protocol                  = "tcp"
 }
 
+resource "aws_vpc_security_group_ingress_rule" "ecs_tasks_from_public_alb_5001" {
+  security_group_id            = aws_security_group.ecs_tasks.id
+  referenced_security_group_id = aws_security_group.public_alb.id
+  from_port                    = 5001
+  to_port                      = 5001
+  ip_protocol                  = "tcp"
+}
+
 resource "aws_vpc_security_group_ingress_rule" "ecs_tasks_from_internal_alb_5000_5003" {
   security_group_id            = aws_security_group.ecs_tasks.id
   referenced_security_group_id = aws_security_group.internal_alb.id
@@ -587,6 +595,50 @@ resource "aws_lb_listener" "public_test" {
 
   lifecycle {
     ignore_changes = [default_action]
+  }
+}
+
+resource "aws_lb_listener_rule" "ext_payments_public_prod" {
+  listener_arn = aws_lb_listener.public_prod.arn
+  priority     = 10
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.blue["ext-payments"].arn
+  }
+
+  condition {
+    path_pattern {
+      values = [
+        "/ext-payments/api/v1/health",
+        "/ext-payments/api/v1/payment-intents",
+        "/ext-payments/api/v1/payment-intents/*",
+        "/ext-payments/api/v1/payments",
+        "/ext-payments/api/v1/payments/*",
+      ]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "ext_payments_public_test" {
+  listener_arn = aws_lb_listener.public_test.arn
+  priority     = 10
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.green["ext-payments"].arn
+  }
+
+  condition {
+    path_pattern {
+      values = [
+        "/ext-payments/api/v1/health",
+        "/ext-payments/api/v1/payment-intents",
+        "/ext-payments/api/v1/payment-intents/*",
+        "/ext-payments/api/v1/payments",
+        "/ext-payments/api/v1/payments/*",
+      ]
+    }
   }
 }
 

--- a/infra/aws/terraform/outputs.tf
+++ b/infra/aws/terraform/outputs.tf
@@ -96,6 +96,14 @@ output "api_cloudfront_domain_name" {
   value = aws_cloudfront_distribution.api.domain_name
 }
 
+output "ext_payments_public_base_url" {
+  value = "https://${aws_cloudfront_distribution.api.domain_name}/ext-payments/api/v1"
+}
+
+output "ext_payments_public_health_url" {
+  value = "https://${aws_cloudfront_distribution.api.domain_name}/ext-payments/api/v1/health"
+}
+
 output "frontend_buckets" {
   value = {
     for name, bucket in aws_s3_bucket.frontends : name => bucket.bucket

--- a/microservices/ext-payments/app/__init__.py
+++ b/microservices/ext-payments/app/__init__.py
@@ -45,6 +45,8 @@ def create_app(config_name='default'):
     
     from app.api.v1 import api_v1_bp
     app.register_blueprint(api_v1_bp, url_prefix='/api/v1')
+    # Public alias used by ALB path-based routing to expose ext-payments separately.
+    app.register_blueprint(api_v1_bp, name='api_v1_public', url_prefix='/ext-payments/api/v1')
     
     @app.route('/health')
     def health():


### PR DESCRIPTION
This pull request introduces new infrastructure and application changes to support exposing the `ext-payments` service via a dedicated public path through the ALB and CloudFront, as well as providing new Terraform outputs for easier integration. The main changes include updates to security group rules, ALB listener rules, application routing, and Terraform outputs.

**Infrastructure: ALB and Security Group Configuration**

* Added a new security group ingress rule to allow traffic from the public ALB to ECS tasks on port 5001, enabling the new public endpoint for `ext-payments`.
* Created new ALB listener rules for both production and test environments to forward requests matching `/ext-payments/api/v1/*` paths to the appropriate `ext-payments` target groups (`blue` for prod, `green` for test).

**Application: Routing**

* Registered the `api_v1_bp` blueprint with a new public alias (`/ext-payments/api/v1`) in the `ext-payments` Flask app to serve requests routed by the ALB to the new path.

**Infrastructure: Outputs**

* Added new Terraform outputs for the base URL and health URL of the public `ext-payments` endpoint, making it easier to reference these URLs in other modules or documentation.