### PR TITLE
Feature/sprint2 deploy 2

### DIFF
--- a/infra/aws/codebuild/deploy.sh
+++ b/infra/aws/codebuild/deploy.sh
@@ -136,7 +136,7 @@ PY
 
 deploy_backend_service() {
   local service="$1"
-  local image_repo family log_group app_name group_name port image_uri taskdef_file taskdef_arn appspec_file deploy_input_file deployment_id status attempts
+  local image_repo family log_group app_name group_name port image_uri taskdef_file taskdef_arn appspec_file deploy_input_file deployment_id status attempts cluster_name service_name
 
   image_repo=$(jq -r --arg s "$service" '.ecr_repositories.value[$s]' "$TF_OUTPUTS")
   family=$(jq -r --arg s "$service" '.service_families.value[$s]' "$TF_OUTPUTS")
@@ -148,6 +148,18 @@ deploy_backend_service() {
 
   taskdef_file=$(render_taskdef "$service" "$image_uri" "$family" "$log_group") || return 0
   taskdef_arn=$(aws ecs register-task-definition --cli-input-json "file://${taskdef_file}" --query 'taskDefinition.taskDefinitionArn' --output text)
+
+  if [[ "$app_name" == "null" || "$group_name" == "null" || -z "$app_name" || -z "$group_name" ]]; then
+    cluster_name=$(jq -r '.ecs_cluster_name.value' "$TF_OUTPUTS")
+    service_name=$(jq -r --arg s "$service" '.ecs_services.value[$s]' "$TF_OUTPUTS")
+    echo "CodeDeploy not configured for ${service}. Using ECS rolling deployment."
+    aws ecs update-service \
+      --cluster "$cluster_name" \
+      --service "$service_name" \
+      --task-definition "$taskdef_arn" \
+      --force-new-deployment >/dev/null
+    return 0
+  fi
 
   appspec_file="/tmp/${service}-appspec.json"
   jq -n --arg taskdef "$taskdef_arn" --arg container "$service" --argjson port "$port" '{version:1,Resources:[{TargetService:{Type:"AWS::ECS::Service",Properties:{TaskDefinition:$taskdef,LoadBalancerInfo:{ContainerName:$container,ContainerPort:$port},PlatformVersion:"LATEST"}}}]}' > "$appspec_file"
@@ -203,6 +215,11 @@ deploy_backends() {
     cluster_name=$(jq -r '.ecs_cluster_name.value' "$TF_OUTPUTS")
     service_name=$(jq -r --arg s "$service" '.ecs_services.value[$s]' "$TF_OUTPUTS")
     prod_listener_arn=$(jq -r --arg s "$service" '.codedeploy_prod_listener_arns.value[$s]' "$TF_OUTPUTS")
+
+    if [[ "$prod_listener_arn" == "null" || -z "$prod_listener_arn" ]]; then
+      echo "Skipping listener reconcile for ${service}: no CodeDeploy listener configured"
+      return 0
+    fi
 
     expected_target_group=$(aws ecs describe-services \
       --cluster "$cluster_name" \

--- a/infra/aws/terraform/main.tf
+++ b/infra/aws/terraform/main.tf
@@ -70,6 +70,10 @@ locals {
     "web-client" = {}
     "web-admin"  = {}
   }
+
+  codedeploy_service_configs = {
+    for key, value in local.service_configs : key => value if key != "ext-payments"
+  }
 }
 
 resource "random_password" "db" {
@@ -568,6 +572,27 @@ resource "aws_lb_target_group" "green" {
   tags = local.common_tags
 }
 
+resource "aws_lb_target_group" "ext_payments_public" {
+  name        = substr("${var.resource_prefix}-ext-pay-pub", 0, 32)
+  port        = local.service_configs["ext-payments"].port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.main.id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    interval            = 30
+    matcher             = "200-399"
+    path                = "/health"
+    protocol            = "HTTP"
+    timeout             = 5
+    unhealthy_threshold = 3
+  }
+
+  tags = local.common_tags
+}
+
 resource "aws_lb_listener" "public_prod" {
   load_balancer_arn = aws_lb.public.arn
   port              = local.service_configs.gateway.prod_port
@@ -604,7 +629,7 @@ resource "aws_lb_listener_rule" "ext_payments_public_prod" {
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.blue["ext-payments"].arn
+    target_group_arn = aws_lb_target_group.ext_payments_public.arn
   }
 
   condition {
@@ -626,7 +651,7 @@ resource "aws_lb_listener_rule" "ext_payments_public_test" {
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.green["ext-payments"].arn
+    target_group_arn = aws_lb_target_group.ext_payments_public.arn
   }
 
   condition {
@@ -747,7 +772,7 @@ resource "aws_ecs_service" "services" {
   enable_execute_command            = true
 
   deployment_controller {
-    type = var.enable_codedeploy ? "CODE_DEPLOY" : "ECS"
+    type = (var.enable_codedeploy && each.key != "ext-payments") ? "CODE_DEPLOY" : "ECS"
   }
 
   network_configuration {
@@ -756,10 +781,22 @@ resource "aws_ecs_service" "services" {
     assign_public_ip = true
   }
 
-  load_balancer {
-    target_group_arn = aws_lb_target_group.blue[each.key].arn
-    container_name   = each.key
-    container_port   = each.value.port
+  dynamic "load_balancer" {
+    for_each = each.key == "ext-payments" ? [1] : []
+    content {
+      target_group_arn = aws_lb_target_group.ext_payments_public.arn
+      container_name   = each.key
+      container_port   = each.value.port
+    }
+  }
+
+  dynamic "load_balancer" {
+    for_each = each.key != "ext-payments" ? [1] : []
+    content {
+      target_group_arn = aws_lb_target_group.blue[each.key].arn
+      container_name   = each.key
+      container_port   = each.value.port
+    }
   }
 
   lifecycle {
@@ -1104,13 +1141,13 @@ resource "aws_iam_role_policy_attachment" "github_actions_admin" {
 }
 
 resource "aws_codedeploy_app" "services" {
-  for_each         = var.enable_codedeploy ? local.service_configs : {}
+  for_each         = var.enable_codedeploy ? local.codedeploy_service_configs : {}
   compute_platform = "ECS"
   name             = "${local.name_prefix}-${each.key}"
 }
 
 resource "aws_codedeploy_deployment_group" "services" {
-  for_each = var.enable_codedeploy ? local.service_configs : {}
+  for_each = var.enable_codedeploy ? local.codedeploy_service_configs : {}
 
   app_name               = aws_codedeploy_app.services[each.key].name
   deployment_group_name  = "${local.name_prefix}-${each.key}"

--- a/infra/aws/terraform/outputs.tf
+++ b/infra/aws/terraform/outputs.tf
@@ -60,7 +60,7 @@ output "codedeploy_deployment_groups" {
 
 output "codedeploy_prod_listener_arns" {
   value = var.enable_codedeploy ? {
-    for name, config in local.service_configs : name => (
+    for name, config in local.codedeploy_service_configs : name => (
       name == "gateway" ? aws_lb_listener.public_prod.arn : aws_lb_listener.internal_prod[name].arn
     )
   } : {}

--- a/infra/aws/terraform/taskdefs/pagos.json.tpl
+++ b/infra/aws/terraform/taskdefs/pagos.json.tpl
@@ -24,7 +24,7 @@
       ],
       "environment": [
         { "name": "FLASK_ENV", "value": "production" },
-        { "name": "EXT_PAYMENTS_URL", "value": "http://__INTERNAL_ALB_DNS__:5001" },
+        { "name": "EXT_PAYMENTS_URL", "value": "http://__PUBLIC_ALB_DNS__/ext-payments" },
         { "name": "PAGOS_WEBHOOK_URL", "value": "http://__PUBLIC_ALB_DNS__" },
         { "name": "MQ_HOST", "value": "__MQ_HOST__" },
         { "name": "MQ_PORT", "value": "__MQ_PORT__" },


### PR DESCRIPTION
This pull request updates the deployment and infrastructure configuration to treat the `ext-payments` service differently from other backend services. The main changes ensure that `ext-payments` uses a direct ECS rolling deployment rather than CodeDeploy, and it now has its own public-facing load balancer target group. This separation improves deployment reliability for `ext-payments` and clarifies its routing and deployment path.

Key changes include:

**Deployment Logic Adjustments:**

* Updated `deploy.sh` so that if a service (like `ext-payments`) lacks CodeDeploy configuration, it uses an ECS rolling deployment instead of attempting a CodeDeploy deployment. This avoids deployment errors for services not configured with CodeDeploy. [[1]](diffhunk://#diff-c9562e1785200fe34f8bcc252a34484a9ebf9a39c121ba0508ec4ea0b479a6a9L139-R139) [[2]](diffhunk://#diff-c9562e1785200fe34f8bcc252a34484a9ebf9a39c121ba0508ec4ea0b479a6a9R152-R163)
* Skips listener reconciliation in `deploy.sh` for services without a CodeDeploy listener, preventing unnecessary errors or failed steps during deployment.

**Terraform Infrastructure Changes:**

* Introduced a new local variable `codedeploy_service_configs` that excludes `ext-payments`, ensuring CodeDeploy resources are only created for the appropriate services. All relevant CodeDeploy resources and outputs now use this filtered set. [[1]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090R73-R76) [[2]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090L1107-R1150) [[3]](diffhunk://#diff-a87d1a485338d836af6d9cd53927d0a7c0efb04bbf9947fbbd95adc6da87f5fcL63-R63)
* Created a dedicated `aws_lb_target_group` resource for `ext-payments` and updated listener rules so that traffic to `/ext-payments` is routed to this new public target group, rather than the blue/green target groups used for other services. [[1]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090R575-R595) [[2]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090L607-R632) [[3]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090L629-R654)
* Modified the `aws_ecs_service` resource to use an ECS deployment controller for `ext-payments` (rather than CodeDeploy) and to attach the correct load balancer target group dynamically, ensuring proper service registration and traffic routing. [[1]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090L750-R775) [[2]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090L759-R800)

**Configuration Updates:**

* Updated the `pagos` task definition template so that the `EXT_PAYMENTS_URL` now points to the public ALB at `/ext-payments` instead of the internal ALB, reflecting the new public routing for this service.