### PR TITLE
sprint 2 deploy 3

### DIFF
--- a/infra/aws/codebuild/deploy.sh
+++ b/infra/aws/codebuild/deploy.sh
@@ -216,7 +216,16 @@ deploy_backends() {
     service_name=$(jq -r --arg s "$service" '.ecs_services.value[$s]' "$TF_OUTPUTS")
     prod_listener_arn=$(jq -r --arg s "$service" '.codedeploy_prod_listener_arns.value[$s]' "$TF_OUTPUTS")
 
-    if [[ "$prod_listener_arn" == "null" || -z "$prod_listener_arn" ]]; then
+    # Trim potential CR/LF from jq output when env vars were created on Windows.
+    service_name="${service_name//$'\r'/}"
+    prod_listener_arn="${prod_listener_arn//$'\r'/}"
+
+    if [[ "$service_name" == "null" || -z "$service_name" ]]; then
+      echo "Skipping listener reconcile for ${service}: ECS service name not found"
+      return 0
+    fi
+
+    if [[ "$prod_listener_arn" == "null" || -z "$prod_listener_arn" || "$prod_listener_arn" != arn:aws*:elasticloadbalancing:*:listener/* ]]; then
       echo "Skipping listener reconcile for ${service}: no CodeDeploy listener configured"
       return 0
     fi


### PR DESCRIPTION
This pull request makes the `deploy.sh` script more robust by improving how it handles environment variables that may contain Windows-style line endings and by adding extra validation for required values before proceeding with deployment steps.

Validation and robustness improvements in backend deployment:

* Trimmed carriage return characters (`\r`) from `service_name` and `prod_listener_arn` to handle possible Windows line endings in environment variables.
* Added a check to skip listener reconciliation if `service_name` is missing or null, with a clear log message.
* Enhanced the validation for `prod_listener_arn` to ensure it matches the expected AWS ARN format before proceeding, preventing misconfiguration.