### PR TITLE
sprint 2 deploy 3

### DIFF
--- a/infra/aws/codebuild/deploy.sh
+++ b/infra/aws/codebuild/deploy.sh
@@ -216,7 +216,16 @@ deploy_backends() {
     service_name=$(jq -r --arg s "$service" '.ecs_services.value[$s]' "$TF_OUTPUTS")
     prod_listener_arn=$(jq -r --arg s "$service" '.codedeploy_prod_listener_arns.value[$s]' "$TF_OUTPUTS")
 
-    if [[ "$prod_listener_arn" == "null" || -z "$prod_listener_arn" ]]; then
+    # Trim potential CR/LF from jq output when env vars were created on Windows.
+    service_name="${service_name//$'\r'/}"
+    prod_listener_arn="${prod_listener_arn//$'\r'/}"
+
+    if [[ "$service_name" == "null" || -z "$service_name" ]]; then
+      echo "Skipping listener reconcile for ${service}: ECS service name not found"
+      return 0
+    fi
+
+    if [[ "$prod_listener_arn" == "null" || -z "$prod_listener_arn" || "$prod_listener_arn" != arn:aws*:elasticloadbalancing:*:listener/* ]]; then
       echo "Skipping listener reconcile for ${service}: no CodeDeploy listener configured"
       return 0
     fi


### PR DESCRIPTION
This pull request improves the robustness of the backend deployment script by adding stricter validation and handling for ECS service names and listener ARNs, especially to address issues caused by Windows-style line endings in environment variables.

Validation and input sanitization:

* Added logic to trim carriage return characters from `service_name` and `prod_listener_arn` to prevent issues when environment variables are created on Windows.
* Added a check to skip listener reconciliation if the ECS service name is missing or null, with a clear log message.
* Enhanced the validation for `prod_listener_arn` to ensure it matches the expected ARN pattern for AWS Elastic Load Balancer listeners before proceeding.