### PR TITLE
sprint 2 deploy 3

### DIFF
--- a/infra/aws/codebuild/deploy.sh
+++ b/infra/aws/codebuild/deploy.sh
@@ -216,7 +216,16 @@ deploy_backends() {
     service_name=$(jq -r --arg s "$service" '.ecs_services.value[$s]' "$TF_OUTPUTS")
     prod_listener_arn=$(jq -r --arg s "$service" '.codedeploy_prod_listener_arns.value[$s]' "$TF_OUTPUTS")
 
-    if [[ "$prod_listener_arn" == "null" || -z "$prod_listener_arn" ]]; then
+    # Trim potential CR/LF from jq output when env vars were created on Windows.
+    service_name="${service_name//$'\r'/}"
+    prod_listener_arn="${prod_listener_arn//$'\r'/}"
+
+    if [[ "$service_name" == "null" || -z "$service_name" ]]; then
+      echo "Skipping listener reconcile for ${service}: ECS service name not found"
+      return 0
+    fi
+
+    if [[ "$prod_listener_arn" == "null" || -z "$prod_listener_arn" || "$prod_listener_arn" != arn:aws*:elasticloadbalancing:*:listener/* ]]; then
       echo "Skipping listener reconcile for ${service}: no CodeDeploy listener configured"
       return 0
     fi


### PR DESCRIPTION
This pull request improves the robustness of the `deploy_backends` function in the `deploy.sh` script by adding stricter validation and handling of environment variables, particularly those that may be affected by Windows-style line endings. The changes help prevent deployment errors due to malformed or missing environment variables.

Validation and input sanitization:

* Trimmed carriage return characters from `service_name` and `prod_listener_arn` variables to handle cases where environment variables were created on Windows.
* Added a check to skip listener reconciliation if `service_name` is missing or null, with a clear log message.
* Enhanced the validation for `prod_listener_arn` to ensure it matches the expected AWS ARN format before proceeding, reducing the risk of misconfiguration.