### PR TITLE
Feature/hu p 21 loginadmin

### DIFF
--- a/.github/workflows/cd-aws-main.yml
+++ b/.github/workflows/cd-aws-main.yml
@@ -168,6 +168,19 @@ jobs:
             service_name=$(jq -r --arg s "$service" '.ecs_services.value[$s]' "$TF_OUTPUTS")
             prod_listener_arn=$(jq -r --arg s "$service" '.codedeploy_prod_listener_arns.value[$s]' "$TF_OUTPUTS")
 
+            service_name="${service_name//$'\r'/}"
+            prod_listener_arn="${prod_listener_arn//$'\r'/}"
+
+            if [[ "$service_name" == "null" || -z "$service_name" ]]; then
+              echo "Skipping listener reconcile for $service: ECS service name not found"
+              return 0
+            fi
+
+            if [[ "$prod_listener_arn" == "null" || -z "$prod_listener_arn" || "$prod_listener_arn" != arn:aws*:elasticloadbalancing:*:listener/* ]]; then
+              echo "Skipping listener reconcile for $service: no CodeDeploy listener configured"
+              return 0
+            fi
+
             expected_target_group=$(aws ecs describe-services \
               --cluster "$cluster_name" \
               --services "$service_name" \
@@ -228,7 +241,7 @@ jobs:
 
           deploy_service() {
             local service="$1"
-            local image_repo family log_group app_name group_name port image_uri taskdef_file taskdef_arn appspec_file deploy_input_file deployment_id status
+            local image_repo family log_group app_name group_name port image_uri taskdef_file taskdef_arn appspec_file deploy_input_file deployment_id status cluster_name service_name
 
             image_repo=$(jq -r --arg s "$service" '.ecr_repositories.value[$s]' "$TF_OUTPUTS")
             family=$(jq -r --arg s "$service" '.service_families.value[$s]' "$TF_OUTPUTS")
@@ -240,6 +253,22 @@ jobs:
 
             taskdef_file=$(render_taskdef "$service" "$image_uri" "$family" "$log_group")
             taskdef_arn=$(aws ecs register-task-definition --cli-input-json "file://$taskdef_file" --query 'taskDefinition.taskDefinitionArn' --output text)
+
+            app_name="${app_name//$'\r'/}"
+            group_name="${group_name//$'\r'/}"
+
+            if [[ "$app_name" == "null" || "$group_name" == "null" || -z "$app_name" || -z "$group_name" ]]; then
+              cluster_name=$(jq -r '.ecs_cluster_name.value' "$TF_OUTPUTS")
+              service_name=$(jq -r --arg s "$service" '.ecs_services.value[$s]' "$TF_OUTPUTS")
+              service_name="${service_name//$'\r'/}"
+              echo "CodeDeploy not configured for $service. Using ECS rolling deployment."
+              aws ecs update-service \
+                --cluster "$cluster_name" \
+                --service "$service_name" \
+                --task-definition "$taskdef_arn" \
+                --force-new-deployment >/dev/null
+              return 0
+            fi
 
             appspec_file="/tmp/${service}-appspec.json"
             jq -n --arg taskdef "$taskdef_arn" --arg container "$service" --argjson port "$port" '{version:1,Resources:[{TargetService:{Type:"AWS::ECS::Service",Properties:{TaskDefinition:$taskdef,LoadBalancerInfo:{ContainerName:$container,ContainerPort:$port},PlatformVersion:"LATEST"}}}]}' > "$appspec_file"


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/cd-aws-main.yml` to improve robustness and error handling when deploying ECS services, especially in scenarios where CodeDeploy or load balancer listeners are not configured. The key changes ensure that deployments gracefully fall back to ECS rolling updates when required configuration is missing, and that input values are sanitized to avoid issues with unexpected characters.

**Deployment logic improvements:**

* Added checks to sanitize and validate `service_name` and `prod_listener_arn` before reconciling listeners, skipping the step if values are missing or malformed.
* Enhanced the `deploy_service` function to sanitize `app_name` and `group_name`, and to detect when CodeDeploy is not configured, falling back to an ECS rolling deployment for the affected service.

**Variable management:**

* Declared `cluster_name` and `service_name` as local variables in the `deploy_service` function to support the new fallback logic.