### PR TITLE
Feature/sprint2 deploy 5

### DIFF
--- a/.github/workflows/cd-aws-main.yml
+++ b/.github/workflows/cd-aws-main.yml
@@ -62,6 +62,33 @@ jobs:
             -backend-config="dynamodb_table=${TF_BACKEND_DYNAMODB_TABLE}" \
             -backend-config="encrypt=true"
 
+      - name: Migrate ext-payments ECS state to dedicated resource
+        working-directory: infra/aws/terraform
+        run: |
+          # Move the ext-payments service from the for_each resource to the dedicated resource
+          # so Terraform recreates it with deployment_controller=ECS instead of CODE_DEPLOY.
+          # This is idempotent: if already moved, `state show` will fail and we skip gracefully.
+          if terraform state show 'aws_ecs_service.services["ext-payments"]' > /dev/null 2>&1; then
+            echo "Moving aws_ecs_service.services[ext-payments] → aws_ecs_service.ext_payments"
+            terraform state mv 'aws_ecs_service.services["ext-payments"]' 'aws_ecs_service.ext_payments' || true
+          else
+            echo "aws_ecs_service.services[ext-payments] not in state (already moved or never existed) – skipping"
+          fi
+          # Same for autoscaling target
+          if terraform state show 'aws_appautoscaling_target.services["ext-payments"]' > /dev/null 2>&1; then
+            echo "Moving aws_appautoscaling_target.services[ext-payments] → aws_appautoscaling_target.ext_payments"
+            terraform state mv 'aws_appautoscaling_target.services["ext-payments"]' 'aws_appautoscaling_target.ext_payments' || true
+          else
+            echo "aws_appautoscaling_target.services[ext-payments] not in state – skipping"
+          fi
+          # Same for autoscaling policy
+          if terraform state show 'aws_appautoscaling_policy.services_cpu["ext-payments"]' > /dev/null 2>&1; then
+            echo "Moving aws_appautoscaling_policy.services_cpu[ext-payments] → aws_appautoscaling_policy.ext_payments_cpu"
+            terraform state mv 'aws_appautoscaling_policy.services_cpu["ext-payments"]' 'aws_appautoscaling_policy.ext_payments_cpu' || true
+          else
+            echo "aws_appautoscaling_policy.services_cpu[ext-payments] not in state – skipping"
+          fi
+
       - name: Terraform apply
         working-directory: infra/aws/terraform
         run: terraform apply -lock-timeout=15m -auto-approve

--- a/infra/aws/terraform/local-plan.tfvars
+++ b/infra/aws/terraform/local-plan.tfvars
@@ -1,0 +1,2 @@
+﻿github_repository = "grupo13/MISW4501-202611-ProyectoFinal-Grupo13"
+aws_region        = "us-east-2"

--- a/infra/aws/terraform/main.tf
+++ b/infra/aws/terraform/main.tf
@@ -759,8 +759,9 @@ resource "aws_ecs_task_definition" "bootstrap" {
   tags = local.common_tags
 }
 
+# ECS services that use CodeDeploy (blue/green) – ext-payments is managed separately below
 resource "aws_ecs_service" "services" {
-  for_each = local.service_configs
+  for_each = local.codedeploy_service_configs
 
   name            = "${local.name_prefix}-${each.key}"
   cluster         = aws_ecs_cluster.main.id
@@ -772,7 +773,7 @@ resource "aws_ecs_service" "services" {
   enable_execute_command            = true
 
   deployment_controller {
-    type = (var.enable_codedeploy && each.key != "ext-payments") ? "CODE_DEPLOY" : "ECS"
+    type = var.enable_codedeploy ? "CODE_DEPLOY" : "ECS"
   }
 
   network_configuration {
@@ -781,22 +782,10 @@ resource "aws_ecs_service" "services" {
     assign_public_ip = true
   }
 
-  dynamic "load_balancer" {
-    for_each = each.key == "ext-payments" ? [1] : []
-    content {
-      target_group_arn = aws_lb_target_group.ext_payments_public.arn
-      container_name   = each.key
-      container_port   = each.value.port
-    }
-  }
-
-  dynamic "load_balancer" {
-    for_each = each.key != "ext-payments" ? [1] : []
-    content {
-      target_group_arn = aws_lb_target_group.blue[each.key].arn
-      container_name   = each.key
-      container_port   = each.value.port
-    }
+  load_balancer {
+    target_group_arn = aws_lb_target_group.blue[each.key].arn
+    container_name   = each.key
+    container_port   = each.value.port
   }
 
   lifecycle {
@@ -818,8 +807,50 @@ resource "aws_ecs_service" "services" {
   tags = local.common_tags
 }
 
+# ext-payments uses ECS rolling deployment (not CodeDeploy blue/green)
+resource "aws_ecs_service" "ext_payments" {
+  name            = "${local.name_prefix}-ext-payments"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.bootstrap["ext-payments"].arn
+  desired_count   = local.service_configs["ext-payments"].desired_count
+  launch_type     = "FARGATE"
+
+  health_check_grace_period_seconds = 60
+  enable_execute_command            = true
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  network_configuration {
+    subnets          = values(aws_subnet.public)[*].id
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.ext_payments_public.arn
+    container_name   = "ext-payments"
+    container_port   = local.service_configs["ext-payments"].port
+  }
+
+  lifecycle {
+    ignore_changes = [
+      desired_count,
+      task_definition,
+    ]
+  }
+
+  depends_on = [
+    aws_lb_listener.public_prod,
+    aws_lb_listener.public_test,
+  ]
+
+  tags = local.common_tags
+}
+
 resource "aws_appautoscaling_target" "services" {
-  for_each = local.service_configs
+  for_each = local.codedeploy_service_configs
 
   max_capacity       = each.value.max_count
   min_capacity       = each.value.desired_count
@@ -829,13 +860,39 @@ resource "aws_appautoscaling_target" "services" {
 }
 
 resource "aws_appautoscaling_policy" "services_cpu" {
-  for_each = local.service_configs
+  for_each = local.codedeploy_service_configs
 
   name               = "${local.name_prefix}-${each.key}-cpu"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.services[each.key].resource_id
   scalable_dimension = aws_appautoscaling_target.services[each.key].scalable_dimension
   service_namespace  = aws_appautoscaling_target.services[each.key].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+
+    target_value       = 60
+    scale_in_cooldown  = 120
+    scale_out_cooldown = 60
+  }
+}
+
+resource "aws_appautoscaling_target" "ext_payments" {
+  max_capacity       = local.service_configs["ext-payments"].max_count
+  min_capacity       = local.service_configs["ext-payments"].desired_count
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.ext_payments.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "ext_payments_cpu" {
+  name               = "${local.name_prefix}-ext-payments-cpu"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ext_payments.resource_id
+  scalable_dimension = aws_appautoscaling_target.ext_payments.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ext_payments.service_namespace
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {

--- a/infra/aws/terraform/outputs.tf
+++ b/infra/aws/terraform/outputs.tf
@@ -11,9 +11,10 @@ output "ecs_cluster_name" {
 }
 
 output "ecs_services" {
-  value = {
-    for name, service in aws_ecs_service.services : name => service.name
-  }
+  value = merge(
+    { for name, service in aws_ecs_service.services : name => service.name },
+    { "ext-payments" = aws_ecs_service.ext_payments.name }
+  )
 }
 
 output "ecs_task_execution_role_arn" {


### PR DESCRIPTION
This pull request restructures how the `ext-payments` ECS service is managed in Terraform. Previously, it was part of a shared set of ECS resources managed using CodeDeploy (blue/green deployments). Now, `ext-payments` is managed as a dedicated resource using ECS rolling deployments. The changes ensure a clean migration of Terraform state, update autoscaling resources, and adjust outputs accordingly.

**Migration and resource restructuring:**

* Added a migration step in the GitHub Actions workflow (`cd-aws-main.yml`) to move the `ext-payments` ECS service and its autoscaling resources from the shared resources to their new dedicated Terraform resources. This ensures a smooth and idempotent state transition.

**Terraform resource changes:**

* Split `ext-payments` out of the `aws_ecs_service.services` resource (which now only manages CodeDeploy services) and created a standalone `aws_ecs_service.ext_payments` resource configured for ECS rolling deployments. [[1]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090R762-R764) [[2]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090R810-R853)
* Updated the deployment controller logic so that only services in `codedeploy_service_configs` use CodeDeploy, while `ext-payments` always uses ECS.
* Adjusted load balancer configuration so `ext-payments` has its own dedicated load balancer block, while other services use the shared blue/green target groups.
* Created dedicated autoscaling target and policy resources for `ext-payments`, separating them from the shared resources. [[1]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090R882-R907) [[2]](diffhunk://#diff-d0b9ecba474b7caa124274e73d0f5e59ba8b4f0fff33881abca4cf1e07017090L832-R863)

**Outputs and configuration:**

* Modified the `ecs_services` output to include both the shared services and the new dedicated `ext-payments` service.
* Added a new `local-plan.tfvars` file with repository and region configuration.