### PR TITLE
Feature/sprint2

### DIFF
--- a/frontends/web-admin/src/app/core/i18n/translations.ts
+++ b/frontends/web-admin/src/app/core/i18n/translations.ts
@@ -1,0 +1,670 @@
+export type LanguageCode = 'en' | 'es' | 'pt';
+
+export interface AdminTranslation {
+  // Common / Language selector
+  'common.language': string;
+  'common.logout': string;
+  'common.save': string;
+  'common.cancel': string;
+  'common.active': string;
+  'common.saving': string;
+  'common.retry': string;
+  'common.export': string;
+  'common.filter': string;
+  'common.clearFilters': string;
+  'common.loading': string;
+  'common.needHelp': string;
+  'common.name': string;
+
+  // Sidebar
+  'sidebar.dashboard': string;
+  'sidebar.reservations': string;
+  'sidebar.properties': string;
+  'sidebar.guests': string;
+  'sidebar.revenue': string;
+  'sidebar.settings': string;
+
+  // Footer
+  'footer.copyright': string;
+  'footer.privacyPolicy': string;
+  'footer.termsOfService': string;
+  'footer.security': string;
+
+  // Login page
+  'login.needHelp': string;
+  'login.title': string;
+  'login.subtitle': string;
+  'login.email': string;
+  'login.emailPlaceholder': string;
+  'login.password': string;
+  'login.passwordPlaceholder': string;
+  'login.mfaCode': string;
+  'login.mfaCodeHint': string;
+  'login.rememberMe': string;
+  'login.setupAdmin': string;
+  'login.signIn': string;
+  'login.verifySignIn': string;
+
+  // Dashboard
+  'dashboard.title': string;
+  'dashboard.subtitle': string;
+  'dashboard.period.last30': string;
+  'dashboard.period.last7': string;
+  'dashboard.period.last90': string;
+  'dashboard.period.thisYear': string;
+  'dashboard.kpi.totalReservations': string;
+  'dashboard.kpi.fromLastMonth': string;
+  'dashboard.kpi.monthlyRevenue': string;
+  'dashboard.kpi.fromLastMonthRevenue': string;
+  'dashboard.kpi.occupancyRate': string;
+  'dashboard.kpi.aboveAverage': string;
+  'dashboard.kpi.pendingConfirmations': string;
+  'dashboard.kpi.awaitingApproval': string;
+  'dashboard.kpi.needsAttention': string;
+  'dashboard.revenue.title': string;
+  'dashboard.revenue.subtitle': string;
+  'dashboard.revenue.monthly': string;
+  'dashboard.revenue.weekly': string;
+  'dashboard.revenue.daily': string;
+  'dashboard.recent.title': string;
+  'dashboard.recent.subtitle': string;
+  'dashboard.recent.viewAll': string;
+  'dashboard.table.guest': string;
+  'dashboard.table.property': string;
+  'dashboard.table.checkIn': string;
+  'dashboard.table.checkOut': string;
+  'dashboard.table.amount': string;
+  'dashboard.table.status': string;
+
+  // Reservations page
+  'reservations.title': string;
+  'reservations.subtitle': string;
+  'reservations.filter.bookingCode': string;
+  'reservations.filter.searchCode': string;
+  'reservations.filter.checkInFrom': string;
+  'reservations.filter.checkInTo': string;
+  'reservations.filter.status': string;
+  'reservations.filter.allStatus': string;
+  'reservations.filter.roomType': string;
+  'reservations.filter.roomTypePlaceholder': string;
+  'reservations.stats.total': string;
+  'reservations.stats.confirmed': string;
+  'reservations.stats.pending': string;
+  'reservations.stats.cancelledRejected': string;
+  'reservations.list.title': string;
+  'reservations.list.subtitle': string;
+  'reservations.list.loading': string;
+  'reservations.list.noFound': string;
+  'reservations.list.noFoundHint': string;
+  'reservations.table.id': string;
+  'reservations.table.guestId': string;
+  'reservations.table.property': string;
+  'reservations.table.checkIn': string;
+  'reservations.table.checkOut': string;
+  'reservations.table.nights': string;
+  'reservations.table.amount': string;
+  'reservations.table.status': string;
+  'reservations.pagination.showing': string;
+  'reservations.pagination.to': string;
+  'reservations.pagination.of': string;
+  'reservations.pagination.results': string;
+  'reservations.perPage': string;
+
+  // Rate Management (Settings) page
+  'rateManagement.title': string;
+  'rateManagement.subtitle': string;
+  'rateManagement.rateHistory': string;
+  'rateManagement.addRoomType': string;
+  'rateManagement.selectProperty': string;
+  'rateManagement.loadingHotels': string;
+  'rateManagement.noHotels': string;
+  'rateManagement.rooms': string;
+  'rateManagement.noRooms': string;
+  'rateManagement.capacity': string;
+  'rateManagement.beds': string;
+  'rateManagement.addRoom': string;
+  'rateManagement.roomNumber': string;
+  'rateManagement.ratePlans': string;
+  'rateManagement.addPlan': string;
+  'rateManagement.addRule': string;
+  'rateManagement.currencyNote': string;
+  'rateManagement.cancellationPolicy': string;
+  'rateManagement.policy.flexible': string;
+  'rateManagement.policy.flexibleDesc': string;
+  'rateManagement.policy.moderate': string;
+  'rateManagement.policy.moderateDesc': string;
+  'rateManagement.policy.strict': string;
+  'rateManagement.policy.strictDesc': string;
+  'rateManagement.noRatePlans': string;
+  'rateManagement.plan.name': string;
+  'rateManagement.plan.namePlaceholder': string;
+  'rateManagement.plan.description': string;
+  'rateManagement.plan.descPlaceholder': string;
+  'rateManagement.plan.currency': string;
+  'rateManagement.plan.addTitle': string;
+  'rateManagement.plan.saveTitle': string;
+  'rateManagement.plan.rules': string;
+  'rateManagement.plan.noRules': string;
+  'rateManagement.plan.basePrice': string;
+  'rateManagement.plan.minNights': string;
+  'rateManagement.plan.dateFrom': string;
+  'rateManagement.plan.dateTo': string;
+  'rateManagement.plan.priority': string;
+  'rateManagement.tipo.addTitle': string;
+  'rateManagement.tipo.saveTipo': string;
+  'rateManagement.tipo.capacidad': string;
+  'rateManagement.tipo.namePlaceholder': string;
+  'rateManagement.tipo.description': string;
+  'rateManagement.tipo.optionalDesc': string;
+  'rateManagement.room.addTitle': string;
+  'rateManagement.room.saveRoom': string;
+  'rateManagement.rule.addTitle': string;
+  'rateManagement.rule.saveRule': string;
+  'rateManagement.rule.basePriceLabel': string;
+  'rateManagement.rule.minNightsLabel': string;
+  'rateManagement.rule.dateFromLabel': string;
+  'rateManagement.rule.dateToLabel': string;
+  'rateManagement.rule.dateRangeLabel': string;
+  'rateManagement.rule.priorityLabel': string;
+  'rateManagement.table.roomNumber': string;
+  'rateManagement.table.capacity': string;
+  'rateManagement.table.beds': string;
+  'rateManagement.table.actions': string;
+}
+
+export const translations: Record<LanguageCode, AdminTranslation> = {
+  en: {
+    'common.language': 'Language',
+    'common.logout': 'Logout',
+    'common.save': 'Save',
+    'common.cancel': 'Cancel',
+    'common.active': 'Active',
+    'common.saving': 'Saving...',
+    'common.retry': 'Retry',
+    'common.export': 'Export',
+    'common.filter': 'Filter',
+    'common.clearFilters': 'Clear filters',
+    'common.loading': 'Loading...',
+    'common.needHelp': 'Need Help?',
+    'common.name': 'Name',
+
+    'sidebar.dashboard': 'Dashboard',
+    'sidebar.reservations': 'Reservations',
+    'sidebar.properties': 'Properties',
+    'sidebar.guests': 'Guests',
+    'sidebar.revenue': 'Revenue',
+    'sidebar.settings': 'Settings',
+
+    'footer.copyright': '© 2026 TravelHub. All rights reserved.',
+    'footer.privacyPolicy': 'Privacy Policy',
+    'footer.termsOfService': 'Terms of Service',
+    'footer.security': 'Security',
+
+    'login.needHelp': 'Need Help?',
+    'login.title': 'Admin Portal',
+    'login.subtitle': 'Sign in to manage your hotel properties',
+    'login.email': 'Email Address',
+    'login.emailPlaceholder': 'admin@hotel.com',
+    'login.password': 'Password',
+    'login.passwordPlaceholder': 'Enter your password',
+    'login.mfaCode': 'Verification Code',
+    'login.mfaCodeHint': 'Enter the 6-digit code from your authenticator app',
+    'login.rememberMe': 'Remember me',
+    'login.setupAdmin': 'Setup Admin MFA',
+    'login.signIn': 'Sign in to Admin Portal',
+    'login.verifySignIn': 'Verify & Sign In',
+
+    'dashboard.title': 'Dashboard Overview',
+    'dashboard.subtitle': 'Monitor your hotel performance and reservations',
+    'dashboard.period.last30': 'Last 30 days',
+    'dashboard.period.last7': 'Last 7 days',
+    'dashboard.period.last90': 'Last 90 days',
+    'dashboard.period.thisYear': 'This year',
+    'dashboard.kpi.totalReservations': 'Total Reservations',
+    'dashboard.kpi.fromLastMonth': '+142 from last month',
+    'dashboard.kpi.monthlyRevenue': 'Monthly Revenue',
+    'dashboard.kpi.fromLastMonthRevenue': '+$6,850 from last month',
+    'dashboard.kpi.occupancyRate': 'Occupancy Rate',
+    'dashboard.kpi.aboveAverage': 'Above industry average',
+    'dashboard.kpi.pendingConfirmations': 'Pending Confirmations',
+    'dashboard.kpi.awaitingApproval': 'Awaiting approval',
+    'dashboard.kpi.needsAttention': 'Needs attention',
+    'dashboard.revenue.title': 'Revenue Overview',
+    'dashboard.revenue.subtitle': 'Monthly revenue performance',
+    'dashboard.revenue.monthly': 'Monthly',
+    'dashboard.revenue.weekly': 'Weekly',
+    'dashboard.revenue.daily': 'Daily',
+    'dashboard.recent.title': 'Recent Reservations',
+    'dashboard.recent.subtitle': 'Latest booking activity',
+    'dashboard.recent.viewAll': 'View All',
+    'dashboard.table.guest': 'Guest',
+    'dashboard.table.property': 'Property',
+    'dashboard.table.checkIn': 'Check-in',
+    'dashboard.table.checkOut': 'Check-out',
+    'dashboard.table.amount': 'Amount',
+    'dashboard.table.status': 'Status',
+
+    'reservations.title': 'All Reservations',
+    'reservations.subtitle': 'Manage and monitor all hotel reservations',
+    'reservations.filter.bookingCode': 'Booking Code',
+    'reservations.filter.searchCode': 'Search code...',
+    'reservations.filter.checkInFrom': 'Check-in From',
+    'reservations.filter.checkInTo': 'Check-in To',
+    'reservations.filter.status': 'Status',
+    'reservations.filter.allStatus': 'All Status',
+    'reservations.filter.roomType': 'Room Type',
+    'reservations.filter.roomTypePlaceholder': 'e.g. Suite',
+    'reservations.stats.total': 'Total Reservations',
+    'reservations.stats.confirmed': 'Confirmed',
+    'reservations.stats.pending': 'Pending',
+    'reservations.stats.cancelledRejected': 'Cancelled / Rejected',
+    'reservations.list.title': 'Reservations List',
+    'reservations.list.subtitle': 'Complete list of all reservations',
+    'reservations.list.loading': 'Loading reservations…',
+    'reservations.list.noFound': 'No reservations found',
+    'reservations.list.noFoundHint': 'Try adjusting your filters or check back later.',
+    'reservations.table.id': 'ID',
+    'reservations.table.guestId': 'Guest ID',
+    'reservations.table.property': 'Property',
+    'reservations.table.checkIn': 'Check-in',
+    'reservations.table.checkOut': 'Check-out',
+    'reservations.table.nights': 'Nights',
+    'reservations.table.amount': 'Amount',
+    'reservations.table.status': 'Status',
+    'reservations.pagination.showing': 'Showing',
+    'reservations.pagination.to': 'to',
+    'reservations.pagination.of': 'of',
+    'reservations.pagination.results': 'reservations',
+    'reservations.perPage': 'per page',
+
+    'rateManagement.title': 'Room & Rate Management',
+    'rateManagement.subtitle': 'Manage rooms, rates, discounts, and cancellation policies',
+    'rateManagement.rateHistory': 'Rate History',
+    'rateManagement.addRoomType': 'Add Room Type',
+    'rateManagement.selectProperty': 'Select Property',
+    'rateManagement.loadingHotels': 'Loading hotels...',
+    'rateManagement.noHotels': 'No hotels assigned to your account. Contact a super admin.',
+    'rateManagement.rooms': 'Rooms',
+    'rateManagement.noRooms': 'No rooms yet for this type. Add one above.',
+    'rateManagement.capacity': 'Capacity',
+    'rateManagement.beds': 'Beds',
+    'rateManagement.addRoom': 'Add Room',
+    'rateManagement.roomNumber': 'Room #',
+    'rateManagement.ratePlans': 'Rate Plans',
+    'rateManagement.addPlan': 'Add Plan',
+    'rateManagement.addRule': 'Add Rule',
+    'rateManagement.currencyNote': 'All plans are stored in USD',
+    'rateManagement.cancellationPolicy': 'Cancellation Policy',
+    'rateManagement.policy.flexible': 'Flexible',
+    'rateManagement.policy.flexibleDesc': 'Free cancellation 24h before',
+    'rateManagement.policy.moderate': 'Moderate',
+    'rateManagement.policy.moderateDesc': 'Free cancellation 7 days before',
+    'rateManagement.policy.strict': 'Strict',
+    'rateManagement.policy.strictDesc': 'Non-refundable',
+    'rateManagement.noRatePlans': 'No rate plans yet. Add one above.',
+    'rateManagement.plan.name': 'Plan Name *',
+    'rateManagement.plan.namePlaceholder': 'e.g. Standard, Weekday Special',
+    'rateManagement.plan.description': 'Description',
+    'rateManagement.plan.descPlaceholder': 'Optional',
+    'rateManagement.plan.currency': 'Currency',
+    'rateManagement.plan.addTitle': 'Add Rate Plan',
+    'rateManagement.plan.saveTitle': 'Save Plan',
+    'rateManagement.plan.rules': 'Pricing Rules',
+    'rateManagement.plan.noRules': 'No pricing rules yet. Add one above.',
+    'rateManagement.plan.basePrice': 'Base Price / Night ($)',
+    'rateManagement.plan.minNights': 'Min Nights',
+    'rateManagement.plan.dateFrom': 'Date From',
+    'rateManagement.plan.dateTo': 'Date To',
+    'rateManagement.plan.priority': 'Priority',
+    'rateManagement.tipo.addTitle': 'Add Room Type',
+    'rateManagement.tipo.saveTipo': 'Save Room Type',
+    'rateManagement.tipo.capacidad': 'Capacity *',
+    'rateManagement.tipo.namePlaceholder': 'e.g. Deluxe Suite',
+    'rateManagement.tipo.description': 'Description',
+    'rateManagement.tipo.optionalDesc': 'Optional description',
+    'rateManagement.room.addTitle': 'Add Room',
+    'rateManagement.room.saveRoom': 'Save Room',
+    'rateManagement.rule.addTitle': 'Add Pricing Rule',
+    'rateManagement.rule.saveRule': 'Save Rule',
+    'rateManagement.rule.basePriceLabel': 'Base Price / Night ($) *',
+    'rateManagement.rule.minNightsLabel': 'Min Nights',
+    'rateManagement.rule.dateFromLabel': 'Date From',
+    'rateManagement.rule.dateToLabel': 'Date To',
+    'rateManagement.rule.dateRangeLabel': 'Date Range',
+    'rateManagement.rule.priorityLabel': 'Priority',
+    'rateManagement.table.roomNumber': 'Room #',
+    'rateManagement.table.capacity': 'Capacity',
+    'rateManagement.table.beds': 'Beds',
+    'rateManagement.table.actions': 'Actions',
+  },
+
+  es: {
+    'common.language': 'Idioma',
+    'common.logout': 'Cerrar sesión',
+    'common.save': 'Guardar',
+    'common.cancel': 'Cancelar',
+    'common.active': 'Activo',
+    'common.saving': 'Guardando...',
+    'common.retry': 'Reintentar',
+    'common.export': 'Exportar',
+    'common.filter': 'Filtrar',
+    'common.clearFilters': 'Limpiar filtros',
+    'common.loading': 'Cargando...',
+    'common.needHelp': '¿Necesitas ayuda?',
+    'common.name': 'Nombre',
+
+    'sidebar.dashboard': 'Panel',
+    'sidebar.reservations': 'Reservas',
+    'sidebar.properties': 'Propiedades',
+    'sidebar.guests': 'Huéspedes',
+    'sidebar.revenue': 'Ingresos',
+    'sidebar.settings': 'Configuración',
+
+    'footer.copyright': '© 2026 TravelHub. Todos los derechos reservados.',
+    'footer.privacyPolicy': 'Política de privacidad',
+    'footer.termsOfService': 'Términos de servicio',
+    'footer.security': 'Seguridad',
+
+    'login.needHelp': '¿Necesitas ayuda?',
+    'login.title': 'Portal Admin',
+    'login.subtitle': 'Inicia sesión para gestionar tus hoteles',
+    'login.email': 'Correo electrónico',
+    'login.emailPlaceholder': 'admin@hotel.com',
+    'login.password': 'Contraseña',
+    'login.passwordPlaceholder': 'Ingresa tu contraseña',
+    'login.mfaCode': 'Código de verificación',
+    'login.mfaCodeHint': 'Ingresa el código de 6 dígitos de tu app de autenticación',
+    'login.rememberMe': 'Recordarme',
+    'login.setupAdmin': 'Configurar MFA de Admin',
+    'login.signIn': 'Ingresar al Portal Admin',
+    'login.verifySignIn': 'Verificar e ingresar',
+
+    'dashboard.title': 'Resumen del Panel',
+    'dashboard.subtitle': 'Monitorea el rendimiento de tu hotel y las reservas',
+    'dashboard.period.last30': 'Últimos 30 días',
+    'dashboard.period.last7': 'Últimos 7 días',
+    'dashboard.period.last90': 'Últimos 90 días',
+    'dashboard.period.thisYear': 'Este año',
+    'dashboard.kpi.totalReservations': 'Total de reservas',
+    'dashboard.kpi.fromLastMonth': '+142 desde el mes pasado',
+    'dashboard.kpi.monthlyRevenue': 'Ingresos mensuales',
+    'dashboard.kpi.fromLastMonthRevenue': '+$6,850 desde el mes pasado',
+    'dashboard.kpi.occupancyRate': 'Tasa de ocupación',
+    'dashboard.kpi.aboveAverage': 'Por encima del promedio',
+    'dashboard.kpi.pendingConfirmations': 'Confirmaciones pendientes',
+    'dashboard.kpi.awaitingApproval': 'Esperando aprobación',
+    'dashboard.kpi.needsAttention': 'Requiere atención',
+    'dashboard.revenue.title': 'Resumen de ingresos',
+    'dashboard.revenue.subtitle': 'Rendimiento mensual de ingresos',
+    'dashboard.revenue.monthly': 'Mensual',
+    'dashboard.revenue.weekly': 'Semanal',
+    'dashboard.revenue.daily': 'Diario',
+    'dashboard.recent.title': 'Reservas recientes',
+    'dashboard.recent.subtitle': 'Última actividad de reservas',
+    'dashboard.recent.viewAll': 'Ver todas',
+    'dashboard.table.guest': 'Huésped',
+    'dashboard.table.property': 'Propiedad',
+    'dashboard.table.checkIn': 'Entrada',
+    'dashboard.table.checkOut': 'Salida',
+    'dashboard.table.amount': 'Monto',
+    'dashboard.table.status': 'Estado',
+
+    'reservations.title': 'Todas las reservas',
+    'reservations.subtitle': 'Gestiona y monitorea todas las reservas del hotel',
+    'reservations.filter.bookingCode': 'Código de reserva',
+    'reservations.filter.searchCode': 'Buscar código...',
+    'reservations.filter.checkInFrom': 'Entrada desde',
+    'reservations.filter.checkInTo': 'Entrada hasta',
+    'reservations.filter.status': 'Estado',
+    'reservations.filter.allStatus': 'Todos los estados',
+    'reservations.filter.roomType': 'Tipo de habitación',
+    'reservations.filter.roomTypePlaceholder': 'Ej. Suite',
+    'reservations.stats.total': 'Total de reservas',
+    'reservations.stats.confirmed': 'Confirmadas',
+    'reservations.stats.pending': 'Pendientes',
+    'reservations.stats.cancelledRejected': 'Canceladas / Rechazadas',
+    'reservations.list.title': 'Lista de reservas',
+    'reservations.list.subtitle': 'Lista completa de todas las reservas',
+    'reservations.list.loading': 'Cargando reservas…',
+    'reservations.list.noFound': 'No se encontraron reservas',
+    'reservations.list.noFoundHint': 'Intenta ajustar los filtros o vuelve más tarde.',
+    'reservations.table.id': 'ID',
+    'reservations.table.guestId': 'ID Huésped',
+    'reservations.table.property': 'Propiedad',
+    'reservations.table.checkIn': 'Entrada',
+    'reservations.table.checkOut': 'Salida',
+    'reservations.table.nights': 'Noches',
+    'reservations.table.amount': 'Monto',
+    'reservations.table.status': 'Estado',
+    'reservations.pagination.showing': 'Mostrando',
+    'reservations.pagination.to': 'a',
+    'reservations.pagination.of': 'de',
+    'reservations.pagination.results': 'reservas',
+    'reservations.perPage': 'por página',
+
+    'rateManagement.title': 'Gestión de habitaciones y tarifas',
+    'rateManagement.subtitle': 'Gestiona habitaciones, tarifas, descuentos y políticas de cancelación',
+    'rateManagement.rateHistory': 'Historial de tarifas',
+    'rateManagement.addRoomType': 'Agregar tipo de habitación',
+    'rateManagement.selectProperty': 'Seleccionar propiedad',
+    'rateManagement.loadingHotels': 'Cargando hoteles...',
+    'rateManagement.noHotels': 'No tienes hoteles asignados. Contacta a un super administrador.',
+    'rateManagement.rooms': 'Habitaciones',
+    'rateManagement.noRooms': 'Aún no hay habitaciones para este tipo. Agrega una arriba.',
+    'rateManagement.capacity': 'Capacidad',
+    'rateManagement.beds': 'Camas',
+    'rateManagement.addRoom': 'Agregar habitación',
+    'rateManagement.roomNumber': 'Hab. #',
+    'rateManagement.ratePlans': 'Planes tarifarios',
+    'rateManagement.addPlan': 'Agregar plan',
+    'rateManagement.addRule': 'Agregar regla',
+    'rateManagement.currencyNote': 'Todos los planes se almacenan en USD',
+    'rateManagement.cancellationPolicy': 'Política de cancelación',
+    'rateManagement.policy.flexible': 'Flexible',
+    'rateManagement.policy.flexibleDesc': 'Cancelación gratuita 24h antes',
+    'rateManagement.policy.moderate': 'Moderada',
+    'rateManagement.policy.moderateDesc': 'Cancelación gratuita 7 días antes',
+    'rateManagement.policy.strict': 'Estricta',
+    'rateManagement.policy.strictDesc': 'No reembolsable',
+    'rateManagement.noRatePlans': 'Aún no hay planes tarifarios. Agrega uno arriba.',
+    'rateManagement.plan.name': 'Nombre del plan *',
+    'rateManagement.plan.namePlaceholder': 'Ej. Estándar, Especial entre semana',
+    'rateManagement.plan.description': 'Descripción',
+    'rateManagement.plan.descPlaceholder': 'Opcional',
+    'rateManagement.plan.currency': 'Moneda',
+    'rateManagement.plan.addTitle': 'Agregar plan tarifario',
+    'rateManagement.plan.saveTitle': 'Guardar plan',
+    'rateManagement.plan.rules': 'Reglas de precio',
+    'rateManagement.plan.noRules': 'Aún no hay reglas de precio. Agrega una arriba.',
+    'rateManagement.plan.basePrice': 'Precio base / noche ($)',
+    'rateManagement.plan.minNights': 'Min. noches',
+    'rateManagement.plan.dateFrom': 'Fecha desde',
+    'rateManagement.plan.dateTo': 'Fecha hasta',
+    'rateManagement.plan.priority': 'Prioridad',
+    'rateManagement.tipo.addTitle': 'Agregar tipo de habitación',
+    'rateManagement.tipo.saveTipo': 'Guardar tipo',
+    'rateManagement.tipo.capacidad': 'Capacidad *',
+    'rateManagement.tipo.namePlaceholder': 'ej. Suite Deluxe',
+    'rateManagement.tipo.description': 'Descripción',
+    'rateManagement.tipo.optionalDesc': 'Descripción opcional',
+    'rateManagement.room.addTitle': 'Agregar habitación',
+    'rateManagement.room.saveRoom': 'Guardar habitación',
+    'rateManagement.rule.addTitle': 'Agregar regla de precio',
+    'rateManagement.rule.saveRule': 'Guardar regla',
+    'rateManagement.rule.basePriceLabel': 'Precio base / noche ($) *',
+    'rateManagement.rule.minNightsLabel': 'Min. noches',
+    'rateManagement.rule.dateFromLabel': 'Fecha desde',
+    'rateManagement.rule.dateToLabel': 'Fecha hasta',
+    'rateManagement.rule.dateRangeLabel': 'Rango de fechas',
+    'rateManagement.rule.priorityLabel': 'Prioridad',
+    'rateManagement.table.roomNumber': 'Hab. #',
+    'rateManagement.table.capacity': 'Capacidad',
+    'rateManagement.table.beds': 'Camas',
+    'rateManagement.table.actions': 'Acciones',
+  },
+
+  pt: {
+    'common.language': 'Idioma',
+    'common.logout': 'Sair',
+    'common.save': 'Salvar',
+    'common.cancel': 'Cancelar',
+    'common.active': 'Ativo',
+    'common.saving': 'Salvando...',
+    'common.retry': 'Tentar novamente',
+    'common.export': 'Exportar',
+    'common.filter': 'Filtrar',
+    'common.clearFilters': 'Limpar filtros',
+    'common.loading': 'Carregando...',
+    'common.needHelp': 'Precisa de ajuda?',
+    'common.name': 'Nome',
+
+    'sidebar.dashboard': 'Painel',
+    'sidebar.reservations': 'Reservas',
+    'sidebar.properties': 'Propriedades',
+    'sidebar.guests': 'Hóspedes',
+    'sidebar.revenue': 'Receita',
+    'sidebar.settings': 'Configurações',
+
+    'footer.copyright': '© 2026 TravelHub. Todos os direitos reservados.',
+    'footer.privacyPolicy': 'Política de privacidade',
+    'footer.termsOfService': 'Termos de serviço',
+    'footer.security': 'Segurança',
+
+    'login.needHelp': 'Precisa de ajuda?',
+    'login.title': 'Portal Admin',
+    'login.subtitle': 'Entre para gerenciar suas propriedades de hotel',
+    'login.email': 'Endereço de e-mail',
+    'login.emailPlaceholder': 'admin@hotel.com',
+    'login.password': 'Senha',
+    'login.passwordPlaceholder': 'Digite sua senha',
+    'login.mfaCode': 'Código de verificação',
+    'login.mfaCodeHint': 'Digite o código de 6 dígitos do seu aplicativo autenticador',
+    'login.rememberMe': 'Lembrar-me',
+    'login.setupAdmin': 'Configurar MFA Admin',
+    'login.signIn': 'Entrar no Portal Admin',
+    'login.verifySignIn': 'Verificar e entrar',
+
+    'dashboard.title': 'Visão geral do painel',
+    'dashboard.subtitle': 'Monitore o desempenho do seu hotel e as reservas',
+    'dashboard.period.last30': 'Últimos 30 dias',
+    'dashboard.period.last7': 'Últimos 7 dias',
+    'dashboard.period.last90': 'Últimos 90 dias',
+    'dashboard.period.thisYear': 'Este ano',
+    'dashboard.kpi.totalReservations': 'Total de reservas',
+    'dashboard.kpi.fromLastMonth': '+142 desde o mês passado',
+    'dashboard.kpi.monthlyRevenue': 'Receita mensal',
+    'dashboard.kpi.fromLastMonthRevenue': '+$6.850 desde o mês passado',
+    'dashboard.kpi.occupancyRate': 'Taxa de ocupação',
+    'dashboard.kpi.aboveAverage': 'Acima da média do setor',
+    'dashboard.kpi.pendingConfirmations': 'Confirmações pendentes',
+    'dashboard.kpi.awaitingApproval': 'Aguardando aprovação',
+    'dashboard.kpi.needsAttention': 'Requer atenção',
+    'dashboard.revenue.title': 'Visão geral de receita',
+    'dashboard.revenue.subtitle': 'Desempenho mensal de receita',
+    'dashboard.revenue.monthly': 'Mensal',
+    'dashboard.revenue.weekly': 'Semanal',
+    'dashboard.revenue.daily': 'Diário',
+    'dashboard.recent.title': 'Reservas recentes',
+    'dashboard.recent.subtitle': 'Última atividade de reservas',
+    'dashboard.recent.viewAll': 'Ver todas',
+    'dashboard.table.guest': 'Hóspede',
+    'dashboard.table.property': 'Propriedade',
+    'dashboard.table.checkIn': 'Check-in',
+    'dashboard.table.checkOut': 'Check-out',
+    'dashboard.table.amount': 'Valor',
+    'dashboard.table.status': 'Status',
+
+    'reservations.title': 'Todas as reservas',
+    'reservations.subtitle': 'Gerencie e monitore todas as reservas do hotel',
+    'reservations.filter.bookingCode': 'Código de reserva',
+    'reservations.filter.searchCode': 'Buscar código...',
+    'reservations.filter.checkInFrom': 'Check-in a partir de',
+    'reservations.filter.checkInTo': 'Check-in até',
+    'reservations.filter.status': 'Status',
+    'reservations.filter.allStatus': 'Todos os status',
+    'reservations.filter.roomType': 'Tipo de quarto',
+    'reservations.filter.roomTypePlaceholder': 'Ex. Suite',
+    'reservations.stats.total': 'Total de reservas',
+    'reservations.stats.confirmed': 'Confirmadas',
+    'reservations.stats.pending': 'Pendentes',
+    'reservations.stats.cancelledRejected': 'Canceladas / Rejeitadas',
+    'reservations.list.title': 'Lista de reservas',
+    'reservations.list.subtitle': 'Lista completa de todas as reservas',
+    'reservations.list.loading': 'Carregando reservas…',
+    'reservations.list.noFound': 'Nenhuma reserva encontrada',
+    'reservations.list.noFoundHint': 'Tente ajustar os filtros ou verifique mais tarde.',
+    'reservations.table.id': 'ID',
+    'reservations.table.guestId': 'ID Hóspede',
+    'reservations.table.property': 'Propriedade',
+    'reservations.table.checkIn': 'Check-in',
+    'reservations.table.checkOut': 'Check-out',
+    'reservations.table.nights': 'Noites',
+    'reservations.table.amount': 'Valor',
+    'reservations.table.status': 'Status',
+    'reservations.pagination.showing': 'Mostrando',
+    'reservations.pagination.to': 'a',
+    'reservations.pagination.of': 'de',
+    'reservations.pagination.results': 'reservas',
+    'reservations.perPage': 'por página',
+
+    'rateManagement.title': 'Gestão de quartos e tarifas',
+    'rateManagement.subtitle': 'Gerencie quartos, tarifas, descontos e políticas de cancelamento',
+    'rateManagement.rateHistory': 'Histórico de tarifas',
+    'rateManagement.addRoomType': 'Adicionar tipo de quarto',
+    'rateManagement.selectProperty': 'Selecionar propriedade',
+    'rateManagement.loadingHotels': 'Carregando hotéis...',
+    'rateManagement.noHotels': 'Nenhum hotel atribuído à sua conta. Contate um super admin.',
+    'rateManagement.rooms': 'Quartos',
+    'rateManagement.noRooms': 'Nenhum quarto ainda para este tipo. Adicione um acima.',
+    'rateManagement.capacity': 'Capacidade',
+    'rateManagement.beds': 'Camas',
+    'rateManagement.addRoom': 'Adicionar quarto',
+    'rateManagement.roomNumber': 'Quarto #',
+    'rateManagement.ratePlans': 'Planos tarifários',
+    'rateManagement.addPlan': 'Adicionar plano',
+    'rateManagement.addRule': 'Adicionar regra',
+    'rateManagement.currencyNote': 'Todos os planos são armazenados em USD',
+    'rateManagement.cancellationPolicy': 'Política de cancelamento',
+    'rateManagement.policy.flexible': 'Flexível',
+    'rateManagement.policy.flexibleDesc': 'Cancelamento grátis 24h antes',
+    'rateManagement.policy.moderate': 'Moderada',
+    'rateManagement.policy.moderateDesc': 'Cancelamento grátis 7 dias antes',
+    'rateManagement.policy.strict': 'Rígida',
+    'rateManagement.policy.strictDesc': 'Não reembolsável',
+    'rateManagement.noRatePlans': 'Nenhum plano tarifário ainda. Adicione um acima.',
+    'rateManagement.plan.name': 'Nome do plano *',
+    'rateManagement.plan.namePlaceholder': 'Ex. Padrão, Especial dias úteis',
+    'rateManagement.plan.description': 'Descrição',
+    'rateManagement.plan.descPlaceholder': 'Opcional',
+    'rateManagement.plan.currency': 'Moeda',
+    'rateManagement.plan.addTitle': 'Adicionar plano tarifário',
+    'rateManagement.plan.saveTitle': 'Salvar plano',
+    'rateManagement.plan.rules': 'Regras de preço',
+    'rateManagement.plan.noRules': 'Nenhuma regra de preço ainda. Adicione uma acima.',
+    'rateManagement.plan.basePrice': 'Preço base / noite ($)',
+    'rateManagement.plan.minNights': 'Noites mínimas',
+    'rateManagement.plan.dateFrom': 'Data de início',
+    'rateManagement.plan.dateTo': 'Data de fim',
+    'rateManagement.plan.priority': 'Prioridade',
+    'rateManagement.tipo.addTitle': 'Adicionar tipo de quarto',
+    'rateManagement.tipo.saveTipo': 'Salvar tipo',
+    'rateManagement.tipo.capacidad': 'Capacidade *',
+    'rateManagement.tipo.namePlaceholder': 'ex. Suite Deluxe',
+    'rateManagement.tipo.description': 'Descrição',
+    'rateManagement.tipo.optionalDesc': 'Descrição opcional',
+    'rateManagement.room.addTitle': 'Adicionar quarto',
+    'rateManagement.room.saveRoom': 'Salvar quarto',
+    'rateManagement.rule.addTitle': 'Adicionar regra de preço',
+    'rateManagement.rule.saveRule': 'Salvar regra',
+    'rateManagement.rule.basePriceLabel': 'Preço base / noite ($) *',
+    'rateManagement.rule.minNightsLabel': 'Noites mínimas',
+    'rateManagement.rule.dateFromLabel': 'Data de início',
+    'rateManagement.rule.dateToLabel': 'Data de fim',
+    'rateManagement.rule.dateRangeLabel': 'Intervalo de datas',
+    'rateManagement.rule.priorityLabel': 'Prioridade',
+    'rateManagement.table.roomNumber': 'Quarto #',
+    'rateManagement.table.capacity': 'Capacidade',
+    'rateManagement.table.beds': 'Camas',
+    'rateManagement.table.actions': 'Ações',
+  },
+};

--- a/frontends/web-admin/src/app/core/i18n/translations.ts
+++ b/frontends/web-admin/src/app/core/i18n/translations.ts
@@ -443,7 +443,8 @@ export const translations: Record<LanguageCode, AdminTranslation> = {
     'reservations.perPage': 'por página',
 
     'rateManagement.title': 'Gestión de habitaciones y tarifas',
-    'rateManagement.subtitle': 'Gestiona habitaciones, tarifas, descuentos y políticas de cancelación',
+    'rateManagement.subtitle':
+      'Gestiona habitaciones, tarifas, descuentos y políticas de cancelación',
     'rateManagement.rateHistory': 'Historial de tarifas',
     'rateManagement.addRoomType': 'Agregar tipo de habitación',
     'rateManagement.selectProperty': 'Seleccionar propiedad',

--- a/frontends/web-admin/src/app/core/services/i18n.service.ts
+++ b/frontends/web-admin/src/app/core/services/i18n.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, signal } from '@angular/core';
+import { AdminTranslation, LanguageCode, translations } from '../i18n/translations';
+
+const VALID_LANGUAGES: LanguageCode[] = ['en', 'es', 'pt'];
+
+@Injectable({ providedIn: 'root' })
+export class I18nService {
+  private readonly currentLanguageSignal = signal<LanguageCode>(this.getStoredLanguage());
+  readonly currentLanguage = this.currentLanguageSignal.asReadonly();
+
+  t(key: keyof AdminTranslation): string {
+    return translations[this.currentLanguageSignal()][key] ?? key;
+  }
+
+  setLanguage(lang: LanguageCode): void {
+    this.currentLanguageSignal.set(lang);
+    localStorage.setItem('admin_language', lang);
+  }
+
+  private getStoredLanguage(): LanguageCode {
+    const stored = localStorage.getItem('admin_language');
+    return stored && (VALID_LANGUAGES as string[]).includes(stored)
+      ? (stored as LanguageCode)
+      : 'es';
+  }
+}

--- a/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.html
+++ b/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.html
@@ -27,18 +27,36 @@
             <button
               type="button"
               (click)="setLanguage('es')"
-              [class]="currentLanguage === 'es' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >ES</button>
+              [class]="
+                currentLanguage === 'es'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              ES
+            </button>
             <button
               type="button"
               (click)="setLanguage('en')"
-              [class]="currentLanguage === 'en' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >EN</button>
+              [class]="
+                currentLanguage === 'en'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              EN
+            </button>
             <button
               type="button"
               (click)="setLanguage('pt')"
-              [class]="currentLanguage === 'pt' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >PT</button>
+              [class]="
+                currentLanguage === 'pt'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              PT
+            </button>
           </div>
           <a
             href="#"
@@ -66,9 +84,9 @@
 
           <form id="login-form" class="space-y-6" [formGroup]="loginForm" (ngSubmit)="submit()">
             <div id="email-field">
-              <label for="email" class="block text-sm font-medium text-gray-700 mb-2"
-                >{{ t('login.email') }}</label
-              >
+              <label for="email" class="block text-sm font-medium text-gray-700 mb-2">{{
+                t('login.email')
+              }}</label>
               <div class="relative">
                 <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <i class="fas fa-envelope text-gray-400 text-sm"></i>
@@ -86,9 +104,9 @@
             </div>
 
             <div id="password-field">
-              <label for="password" class="block text-sm font-medium text-gray-700 mb-2"
-                >{{ t('login.password') }}</label
-              >
+              <label for="password" class="block text-sm font-medium text-gray-700 mb-2">{{
+                t('login.password')
+              }}</label>
               <div class="relative">
                 <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <i class="fas fa-lock text-gray-400 text-sm"></i>
@@ -119,9 +137,9 @@
             </div>
 
             <div id="mfa-field" *ngIf="showMfaField">
-              <label for="mfa-code" class="block text-sm font-medium text-gray-700 mb-2"
-                >{{ t('login.mfaCode') }}</label
-              >
+              <label for="mfa-code" class="block text-sm font-medium text-gray-700 mb-2">{{
+                t('login.mfaCode')
+              }}</label>
               <div class="relative">
                 <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <i class="fas fa-mobile-alt text-gray-400 text-sm"></i>
@@ -151,9 +169,9 @@
                   type="checkbox"
                   class="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
                 />
-                <label for="remember-me" class="ml-2 block text-sm text-gray-700"
-                  >{{ t('login.rememberMe') }}</label
-                >
+                <label for="remember-me" class="ml-2 block text-sm text-gray-700">{{
+                  t('login.rememberMe')
+                }}</label>
               </div>
               <div class="text-sm">
                 <a

--- a/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.html
+++ b/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.html
@@ -22,10 +22,28 @@
           </div>
         </div>
         <div class="flex items-center space-x-4">
+          <!-- Language selector -->
+          <div class="flex items-center gap-1">
+            <button
+              type="button"
+              (click)="setLanguage('es')"
+              [class]="currentLanguage === 'es' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >ES</button>
+            <button
+              type="button"
+              (click)="setLanguage('en')"
+              [class]="currentLanguage === 'en' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >EN</button>
+            <button
+              type="button"
+              (click)="setLanguage('pt')"
+              [class]="currentLanguage === 'pt' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >PT</button>
+          </div>
           <a
             href="#"
             class="text-gray-600 hover:text-primary-600 text-sm font-medium transition-colors"
-            >Need Help?</a
+            >{{ t('login.needHelp') }}</a
           >
         </div>
       </div>
@@ -42,14 +60,14 @@
                 <i class="fas fa-shield-halved text-primary-600 text-2xl"></i>
               </div>
             </div>
-            <h2 class="text-2xl font-bold text-gray-900 mb-2">Admin Portal</h2>
-            <p class="text-gray-600 text-sm">Sign in to manage your hotel properties</p>
+            <h2 class="text-2xl font-bold text-gray-900 mb-2">{{ t('login.title') }}</h2>
+            <p class="text-gray-600 text-sm">{{ t('login.subtitle') }}</p>
           </div>
 
           <form id="login-form" class="space-y-6" [formGroup]="loginForm" (ngSubmit)="submit()">
             <div id="email-field">
               <label for="email" class="block text-sm font-medium text-gray-700 mb-2"
-                >Email Address</label
+                >{{ t('login.email') }}</label
               >
               <div class="relative">
                 <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -60,7 +78,7 @@
                   name="email"
                   type="email"
                   required
-                  placeholder="admin@hotel.com"
+                  [placeholder]="t('login.emailPlaceholder')"
                   formControlName="email"
                   class="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-xl placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm transition-colors"
                 />
@@ -69,7 +87,7 @@
 
             <div id="password-field">
               <label for="password" class="block text-sm font-medium text-gray-700 mb-2"
-                >Password</label
+                >{{ t('login.password') }}</label
               >
               <div class="relative">
                 <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -80,7 +98,7 @@
                   name="password"
                   [type]="showPassword ? 'text' : 'password'"
                   required
-                  placeholder="Enter your password"
+                  [placeholder]="t('login.passwordPlaceholder')"
                   formControlName="password"
                   class="block w-full pl-10 pr-12 py-3 border border-gray-300 rounded-xl placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm transition-colors"
                 />
@@ -102,7 +120,7 @@
 
             <div id="mfa-field" *ngIf="showMfaField">
               <label for="mfa-code" class="block text-sm font-medium text-gray-700 mb-2"
-                >Verification Code</label
+                >{{ t('login.mfaCode') }}</label
               >
               <div class="relative">
                 <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -119,7 +137,7 @@
                 />
               </div>
               <p class="text-xs text-gray-500 mt-2">
-                Enter the 6-digit code from your authenticator app
+                {{ t('login.mfaCodeHint') }}
               </p>
             </div>
 
@@ -134,14 +152,14 @@
                   class="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
                 />
                 <label for="remember-me" class="ml-2 block text-sm text-gray-700"
-                  >Remember me</label
+                  >{{ t('login.rememberMe') }}</label
                 >
               </div>
               <div class="text-sm">
                 <a
                   [routerLink]="['/setup-admin']"
                   class="font-medium text-primary-600 hover:text-primary-500 transition-colors"
-                  >Setup Admin MFA</a
+                  >{{ t('login.setupAdmin') }}</a
                 >
               </div>
             </div>
@@ -157,7 +175,7 @@
                     class="fas fa-sign-in-alt text-primary-200 group-hover:text-primary-100 text-sm"
                   ></i>
                 </span>
-                {{ showMfaField ? 'Verify & Sign In' : 'Sign in to Admin Portal' }}
+                {{ showMfaField ? t('login.verifySignIn') : t('login.signIn') }}
               </button>
             </div>
           </form>

--- a/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.ts
+++ b/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.ts
@@ -5,6 +5,8 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 import { AuthService } from '../../../../core/services/auth.service';
 import { AdminLoginStep1Response } from '../../../../core/models/auth.models';
+import { I18nService } from '../../../../core/services/i18n.service';
+import { LanguageCode } from '../../../../core/i18n/translations';
 
 @Component({
   selector: 'app-login-page',
@@ -28,6 +30,7 @@ export class LoginPageComponent {
     private readonly route: ActivatedRoute,
     private readonly ngZone: NgZone,
     private readonly cdr: ChangeDetectorRef,
+    readonly i18n: I18nService,
   ) {
     this.loginForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
@@ -104,5 +107,17 @@ export class LoginPageComponent {
 
   togglePassword(): void {
     this.showPassword = !this.showPassword;
+  }
+
+  t(key: Parameters<I18nService['t']>[0]): string {
+    return this.i18n.t(key);
+  }
+
+  get currentLanguage() {
+    return this.i18n.currentLanguage();
+  }
+
+  setLanguage(lang: LanguageCode): void {
+    this.i18n.setLanguage(lang);
   }
 }

--- a/frontends/web-admin/src/app/features/private/pages/dashboard-page/dashboard-page.component.html
+++ b/frontends/web-admin/src/app/features/private/pages/dashboard-page/dashboard-page.component.html
@@ -17,6 +17,24 @@
           </div>
         </div>
         <div class="flex items-center space-x-4">
+          <!-- Language selector -->
+          <div class="flex items-center gap-1">
+            <button
+              type="button"
+              (click)="setLanguage('es')"
+              [class]="currentLanguage === 'es' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >ES</button>
+            <button
+              type="button"
+              (click)="setLanguage('en')"
+              [class]="currentLanguage === 'en' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >EN</button>
+            <button
+              type="button"
+              (click)="setLanguage('pt')"
+              [class]="currentLanguage === 'pt' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >PT</button>
+          </div>
           <button
             class="relative p-2 text-gray-600 hover:text-primary-600 transition-colors"
             type="button"
@@ -50,42 +68,42 @@
           class="flex items-center px-4 py-3 text-sm font-medium text-white bg-primary-600 rounded-xl transition-colors"
         >
           <i class="fas fa-chart-line w-5 mr-3"></i>
-          Dashboard
+          {{ t('sidebar.dashboard') }}
         </a>
         <a
           [routerLink]="['/reservations']"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
           <i class="fas fa-calendar-check w-5 mr-3"></i>
-          Reservations
+          {{ t('sidebar.reservations') }}
         </a>
         <a
           href="#"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
           <i class="fas fa-hotel w-5 mr-3"></i>
-          Properties
+          {{ t('sidebar.properties') }}
         </a>
         <a
           href="#"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
           <i class="fas fa-users w-5 mr-3"></i>
-          Guests
+          {{ t('sidebar.guests') }}
         </a>
         <a
           href="#"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
           <i class="fas fa-dollar-sign w-5 mr-3"></i>
-          Revenue
+          {{ t('sidebar.revenue') }}
         </a>
         <a
           [routerLink]="['/room-rate-management']"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
           <i class="fas fa-cog w-5 mr-3"></i>
-          Settings
+          {{ t('sidebar.settings') }}
         </a>
         <div class="pt-4 mt-4 border-t border-gray-100">
           <button
@@ -94,7 +112,7 @@
             (click)="logout()"
           >
             <i class="fas fa-sign-out-alt w-5 mr-3"></i>
-            Logout
+            {{ t('common.logout') }}
           </button>
         </div>
       </nav>
@@ -104,24 +122,24 @@
       <div id="dashboard-header" class="mb-8">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">Dashboard Overview</h1>
-            <p class="text-gray-600 text-sm">Monitor your hotel performance and reservations</p>
+            <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">{{ t('dashboard.title') }}</h1>
+            <p class="text-gray-600 text-sm">{{ t('dashboard.subtitle') }}</p>
           </div>
           <div class="mt-4 sm:mt-0 flex items-center space-x-3">
             <select
               class="px-4 py-2 border border-gray-300 rounded-xl text-sm font-medium text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500"
             >
-              <option>Last 30 days</option>
-              <option>Last 7 days</option>
-              <option>Last 90 days</option>
-              <option>This year</option>
+              <option>{{ t('dashboard.period.last30') }}</option>
+              <option>{{ t('dashboard.period.last7') }}</option>
+              <option>{{ t('dashboard.period.last90') }}</option>
+              <option>{{ t('dashboard.period.thisYear') }}</option>
             </select>
             <button
               class="px-4 py-2 bg-primary-600 text-white rounded-xl text-sm font-medium hover:bg-primary-700 transition-colors"
               type="button"
             >
               <i class="fas fa-download mr-2"></i>
-              Export
+              {{ t('common.export') }}
             </button>
           </div>
         </div>
@@ -143,9 +161,9 @@
               <i class="fas fa-arrow-up mr-1"></i>12%
             </span>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">Total Reservations</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('dashboard.kpi.totalReservations') }}</h3>
           <p class="text-3xl font-bold text-gray-900 mb-1">1,248</p>
-          <p class="text-xs text-gray-500">+142 from last month</p>
+          <p class="text-xs text-gray-500">{{ t('dashboard.kpi.fromLastMonth') }}</p>
         </div>
 
         <div
@@ -160,9 +178,9 @@
               <i class="fas fa-arrow-up mr-1"></i>8.5%
             </span>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">Monthly Revenue</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('dashboard.kpi.monthlyRevenue') }}</h3>
           <p class="text-3xl font-bold text-gray-900 mb-1">$87,420</p>
-          <p class="text-xs text-gray-500">+$6,850 from last month</p>
+          <p class="text-xs text-gray-500">{{ t('dashboard.kpi.fromLastMonthRevenue') }}</p>
         </div>
 
         <div
@@ -177,9 +195,9 @@
               <i class="fas fa-arrow-up mr-1"></i>5.2%
             </span>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">Occupancy Rate</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('dashboard.kpi.occupancyRate') }}</h3>
           <p class="text-3xl font-bold text-gray-900 mb-1">78.5%</p>
-          <p class="text-xs text-gray-500">Above industry average</p>
+          <p class="text-xs text-gray-500">{{ t('dashboard.kpi.aboveAverage') }}</p>
         </div>
 
         <div
@@ -191,12 +209,12 @@
               <i class="fas fa-clock text-orange-600 text-xl"></i>
             </div>
             <span class="text-xs font-medium text-orange-600 bg-orange-50 px-2 py-1 rounded-full"
-              >Needs attention</span
+              >{{ t('dashboard.kpi.needsAttention') }}</span
             >
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">Pending Confirmations</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('dashboard.kpi.pendingConfirmations') }}</h3>
           <p class="text-3xl font-bold text-gray-900 mb-1">24</p>
-          <p class="text-xs text-gray-500">Awaiting approval</p>
+          <p class="text-xs text-gray-500">{{ t('dashboard.kpi.awaitingApproval') }}</p>
         </div>
       </div>
 
@@ -206,27 +224,27 @@
       >
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6">
           <div>
-            <h2 class="text-xl font-bold text-gray-900 mb-1">Revenue Overview</h2>
-            <p class="text-sm text-gray-600">Monthly revenue performance</p>
+            <h2 class="text-xl font-bold text-gray-900 mb-1">{{ t('dashboard.revenue.title') }}</h2>
+            <p class="text-sm text-gray-600">{{ t('dashboard.revenue.subtitle') }}</p>
           </div>
           <div class="mt-4 sm:mt-0 flex space-x-2">
             <button
               class="px-3 py-1.5 text-xs font-medium text-white bg-primary-600 rounded-lg"
               type="button"
             >
-              Monthly
+              {{ t('dashboard.revenue.monthly') }}
             </button>
             <button
               class="px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
               type="button"
             >
-              Weekly
+              {{ t('dashboard.revenue.weekly') }}
             </button>
             <button
               class="px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
               type="button"
             >
-              Daily
+              {{ t('dashboard.revenue.daily') }}
             </button>
           </div>
         </div>
@@ -239,14 +257,14 @@
       >
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6">
           <div>
-            <h2 class="text-xl font-bold text-gray-900 mb-1">Recent Reservations</h2>
-            <p class="text-sm text-gray-600">Latest booking activity</p>
+            <h2 class="text-xl font-bold text-gray-900 mb-1">{{ t('dashboard.recent.title') }}</h2>
+            <p class="text-sm text-gray-600">{{ t('dashboard.recent.subtitle') }}</p>
           </div>
           <button
             class="mt-4 sm:mt-0 px-4 py-2 text-sm font-medium text-primary-600 hover:bg-primary-50 rounded-lg transition-colors"
             type="button"
           >
-            View All
+            {{ t('dashboard.recent.viewAll') }}
             <i class="fas fa-arrow-right ml-2"></i>
           </button>
         </div>
@@ -258,32 +276,32 @@
                 <th
                   class="text-left py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wider"
                 >
-                  Guest
+                  {{ t('dashboard.table.guest') }}
                 </th>
                 <th
                   class="text-left py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wider hidden md:table-cell"
                 >
-                  Property
+                  {{ t('dashboard.table.property') }}
                 </th>
                 <th
                   class="text-left py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wider"
                 >
-                  Check-in
+                  {{ t('dashboard.table.checkIn') }}
                 </th>
                 <th
                   class="text-left py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wider hidden sm:table-cell"
                 >
-                  Check-out
+                  {{ t('dashboard.table.checkOut') }}
                 </th>
                 <th
                   class="text-left py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wider"
                 >
-                  Amount
+                  {{ t('dashboard.table.amount') }}
                 </th>
                 <th
                   class="text-left py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wider"
                 >
-                  Status
+                  {{ t('dashboard.table.status') }}
                 </th>
               </tr>
             </thead>
@@ -339,17 +357,17 @@
     <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
       <div class="flex flex-col sm:flex-row justify-between items-center">
         <div class="flex items-center mb-4 sm:mb-0">
-          <p class="text-sm text-gray-500">© 2024 TravelHub. All rights reserved.</p>
+          <p class="text-sm text-gray-500">{{ t('footer.copyright') }}</p>
         </div>
         <div class="flex items-center space-x-6">
           <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-            >Privacy Policy</a
+            >{{ t('footer.privacyPolicy') }}</a
           >
           <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-            >Terms of Service</a
+            >{{ t('footer.termsOfService') }}</a
           >
           <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-            >Security</a
+            >{{ t('footer.security') }}</a
           >
         </div>
       </div>

--- a/frontends/web-admin/src/app/features/private/pages/dashboard-page/dashboard-page.component.html
+++ b/frontends/web-admin/src/app/features/private/pages/dashboard-page/dashboard-page.component.html
@@ -22,18 +22,36 @@
             <button
               type="button"
               (click)="setLanguage('es')"
-              [class]="currentLanguage === 'es' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >ES</button>
+              [class]="
+                currentLanguage === 'es'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              ES
+            </button>
             <button
               type="button"
               (click)="setLanguage('en')"
-              [class]="currentLanguage === 'en' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >EN</button>
+              [class]="
+                currentLanguage === 'en'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              EN
+            </button>
             <button
               type="button"
               (click)="setLanguage('pt')"
-              [class]="currentLanguage === 'pt' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >PT</button>
+              [class]="
+                currentLanguage === 'pt'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              PT
+            </button>
           </div>
           <button
             class="relative p-2 text-gray-600 hover:text-primary-600 transition-colors"
@@ -122,7 +140,9 @@
       <div id="dashboard-header" class="mb-8">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">{{ t('dashboard.title') }}</h1>
+            <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
+              {{ t('dashboard.title') }}
+            </h1>
             <p class="text-gray-600 text-sm">{{ t('dashboard.subtitle') }}</p>
           </div>
           <div class="mt-4 sm:mt-0 flex items-center space-x-3">
@@ -161,7 +181,9 @@
               <i class="fas fa-arrow-up mr-1"></i>12%
             </span>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('dashboard.kpi.totalReservations') }}</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">
+            {{ t('dashboard.kpi.totalReservations') }}
+          </h3>
           <p class="text-3xl font-bold text-gray-900 mb-1">1,248</p>
           <p class="text-xs text-gray-500">{{ t('dashboard.kpi.fromLastMonth') }}</p>
         </div>
@@ -178,7 +200,9 @@
               <i class="fas fa-arrow-up mr-1"></i>8.5%
             </span>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('dashboard.kpi.monthlyRevenue') }}</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">
+            {{ t('dashboard.kpi.monthlyRevenue') }}
+          </h3>
           <p class="text-3xl font-bold text-gray-900 mb-1">$87,420</p>
           <p class="text-xs text-gray-500">{{ t('dashboard.kpi.fromLastMonthRevenue') }}</p>
         </div>
@@ -195,7 +219,9 @@
               <i class="fas fa-arrow-up mr-1"></i>5.2%
             </span>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('dashboard.kpi.occupancyRate') }}</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">
+            {{ t('dashboard.kpi.occupancyRate') }}
+          </h3>
           <p class="text-3xl font-bold text-gray-900 mb-1">78.5%</p>
           <p class="text-xs text-gray-500">{{ t('dashboard.kpi.aboveAverage') }}</p>
         </div>
@@ -208,11 +234,13 @@
             <div class="w-12 h-12 bg-orange-100 rounded-xl flex items-center justify-center">
               <i class="fas fa-clock text-orange-600 text-xl"></i>
             </div>
-            <span class="text-xs font-medium text-orange-600 bg-orange-50 px-2 py-1 rounded-full"
-              >{{ t('dashboard.kpi.needsAttention') }}</span
-            >
+            <span class="text-xs font-medium text-orange-600 bg-orange-50 px-2 py-1 rounded-full">{{
+              t('dashboard.kpi.needsAttention')
+            }}</span>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('dashboard.kpi.pendingConfirmations') }}</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">
+            {{ t('dashboard.kpi.pendingConfirmations') }}
+          </h3>
           <p class="text-3xl font-bold text-gray-900 mb-1">24</p>
           <p class="text-xs text-gray-500">{{ t('dashboard.kpi.awaitingApproval') }}</p>
         </div>
@@ -360,15 +388,15 @@
           <p class="text-sm text-gray-500">{{ t('footer.copyright') }}</p>
         </div>
         <div class="flex items-center space-x-6">
-          <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-            >{{ t('footer.privacyPolicy') }}</a
-          >
-          <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-            >{{ t('footer.termsOfService') }}</a
-          >
-          <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-            >{{ t('footer.security') }}</a
-          >
+          <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors">{{
+            t('footer.privacyPolicy')
+          }}</a>
+          <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors">{{
+            t('footer.termsOfService')
+          }}</a>
+          <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors">{{
+            t('footer.security')
+          }}</a>
         </div>
       </div>
     </div>

--- a/frontends/web-admin/src/app/features/private/pages/dashboard-page/dashboard-page.component.ts
+++ b/frontends/web-admin/src/app/features/private/pages/dashboard-page/dashboard-page.component.ts
@@ -3,6 +3,8 @@ import { AfterViewInit, Component } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 
 import { AuthService } from '../../../../core/services/auth.service';
+import { I18nService } from '../../../../core/services/i18n.service';
+import { LanguageCode } from '../../../../core/i18n/translations';
 
 declare const Plotly:
   | {
@@ -93,10 +95,23 @@ export class DashboardPageComponent implements AfterViewInit {
   constructor(
     private readonly authService: AuthService,
     private readonly router: Router,
+    readonly i18n: I18nService,
   ) {}
 
   currentUser() {
     return this.authService.currentUser();
+  }
+
+  t(key: Parameters<I18nService['t']>[0]): string {
+    return this.i18n.t(key);
+  }
+
+  get currentLanguage() {
+    return this.i18n.currentLanguage();
+  }
+
+  setLanguage(lang: LanguageCode): void {
+    this.i18n.setLanguage(lang);
   }
 
   ngAfterViewInit(): void {

--- a/frontends/web-admin/src/app/features/private/pages/rate-management-page/rate-management-page.component.html
+++ b/frontends/web-admin/src/app/features/private/pages/rate-management-page/rate-management-page.component.html
@@ -18,6 +18,24 @@
           </div>
         </div>
         <div class="flex items-center space-x-4">
+          <!-- Language selector -->
+          <div class="flex items-center gap-1">
+            <button
+              type="button"
+              (click)="setLanguage('es')"
+              [class]="currentLanguage === 'es' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >ES</button>
+            <button
+              type="button"
+              (click)="setLanguage('en')"
+              [class]="currentLanguage === 'en' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >EN</button>
+            <button
+              type="button"
+              (click)="setLanguage('pt')"
+              [class]="currentLanguage === 'pt' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >PT</button>
+          </div>
           <button
             class="relative p-2 text-gray-600 hover:text-primary-600 transition-colors"
             type="button"
@@ -52,38 +70,38 @@
           routerLinkActive="text-white bg-primary-600"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
-          <i class="fas fa-chart-line w-5 mr-3"></i>Dashboard
+          <i class="fas fa-chart-line w-5 mr-3"></i>{{ t('sidebar.dashboard') }}
         </a>
         <a
           href="#"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
-          <i class="fas fa-calendar-check w-5 mr-3"></i>Reservations
+          <i class="fas fa-calendar-check w-5 mr-3"></i>{{ t('sidebar.reservations') }}
         </a>
         <a
           href="#"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
-          <i class="fas fa-hotel w-5 mr-3"></i>Properties
+          <i class="fas fa-hotel w-5 mr-3"></i>{{ t('sidebar.properties') }}
         </a>
         <a
           href="#"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
-          <i class="fas fa-users w-5 mr-3"></i>Guests
+          <i class="fas fa-users w-5 mr-3"></i>{{ t('sidebar.guests') }}
         </a>
         <a
           href="#"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
-          <i class="fas fa-dollar-sign w-5 mr-3"></i>Revenue
+          <i class="fas fa-dollar-sign w-5 mr-3"></i>{{ t('sidebar.revenue') }}
         </a>
         <a
           [routerLink]="['/room-rate-management']"
           routerLinkActive="text-white bg-primary-600"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
-          <i class="fas fa-cog w-5 mr-3"></i>Settings
+          <i class="fas fa-cog w-5 mr-3"></i>{{ t('sidebar.settings') }}
         </a>
         <div class="pt-4 mt-4 border-t border-gray-100">
           <button
@@ -91,7 +109,7 @@
             type="button"
             (click)="logout()"
           >
-            <i class="fas fa-sign-out-alt w-5 mr-3"></i>Logout
+            <i class="fas fa-sign-out-alt w-5 mr-3"></i>{{ t('common.logout') }}
           </button>
         </div>
       </nav>
@@ -104,10 +122,10 @@
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
-              Room &amp; Rate Management
+              {{ t('rateManagement.title') }}
             </h1>
             <p class="text-gray-600 text-sm">
-              Manage rooms, rates, discounts, and cancellation policies
+              {{ t('rateManagement.subtitle') }}
             </p>
           </div>
           <div class="mt-4 sm:mt-0 flex items-center space-x-3">
@@ -115,14 +133,14 @@
               class="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-xl text-sm font-medium hover:bg-gray-50 transition-colors"
               type="button"
             >
-              <i class="fas fa-history mr-2"></i>Rate History
+              <i class="fas fa-history mr-2"></i>{{ t('rateManagement.rateHistory') }}
             </button>
             <button
               class="px-4 py-2 bg-primary-600 text-white rounded-xl text-sm font-medium hover:bg-primary-700 transition-colors"
               type="button"
               (click)="openAddTipoModal()"
             >
-              <i class="fas fa-plus mr-2"></i>Add Room Type
+              <i class="fas fa-plus mr-2"></i>{{ t('rateManagement.addRoomType') }}
             </button>
           </div>
         </div>
@@ -140,14 +158,14 @@
       <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 mb-6">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
           <div class="flex-1 max-w-md">
-            <label class="block text-sm font-medium text-gray-700 mb-2">Select Property</label>
+            <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('rateManagement.selectProperty') }}</label>
             @if (loadingHotels()) {
               <div class="flex items-center text-sm text-gray-500">
-                <i class="fas fa-spinner fa-spin mr-2"></i>Loading hotels...
+                <i class="fas fa-spinner fa-spin mr-2"></i>{{ t('rateManagement.loadingHotels') }}
               </div>
             } @else if (hotels().length === 0) {
               <p class="text-sm text-gray-500">
-                No hotels assigned to your account. Contact a super admin.
+                {{ t('rateManagement.noHotels') }}
               </p>
             } @else {
               <select
@@ -212,7 +230,7 @@
               <div class="mb-6">
                 <div class="flex items-center justify-between mb-4">
                   <h4 class="text-sm font-semibold text-gray-900">
-                    Rooms
+                    {{ t('rateManagement.rooms') }}
                     <span
                       class="ml-2 px-2 py-0.5 text-xs bg-blue-100 text-blue-700 rounded-full font-medium"
                     >
@@ -224,23 +242,23 @@
                     class="px-3 py-1.5 bg-blue-600 text-white rounded-lg text-xs font-medium hover:bg-blue-700 transition-colors"
                     (click)="openAddHabitacionModal(tipo.id); $event.stopPropagation()"
                   >
-                    <i class="fas fa-plus mr-1"></i>Add Room
+                    <i class="fas fa-plus mr-1"></i>{{ t('rateManagement.addRoom') }}
                   </button>
                 </div>
 
                 @if (getHabitacionesForTipo(tipo.id).length === 0) {
                   <p class="text-sm text-gray-500 py-2">
-                    No rooms yet for this type. Add one above.
+                    {{ t('rateManagement.noRooms') }}
                   </p>
                 } @else {
                   <div class="overflow-x-auto">
                     <table class="w-full text-xs">
                       <thead>
                         <tr class="text-left text-gray-500 border-b border-gray-100">
-                          <th class="pb-2 pr-4 font-medium">Room #</th>
-                          <th class="pb-2 pr-4 font-medium">Capacity</th>
-                          <th class="pb-2 pr-4 font-medium">Beds</th>
-                          <th class="pb-2 font-medium">Actions</th>
+                          <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.table.roomNumber') }}</th>
+                          <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.table.capacity') }}</th>
+                          <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.table.beds') }}</th>
+                          <th class="pb-2 font-medium">{{ t('rateManagement.table.actions') }}</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -278,14 +296,14 @@
                                     class="text-blue-600 hover:text-blue-800 font-medium"
                                     (click)="saveHabitacion(hab, tipo.id)"
                                   >
-                                    Save
+                                    {{ t('common.save') }}
                                   </button>
                                   <button
                                     type="button"
                                     class="text-gray-400 hover:text-gray-600"
                                     (click)="cancelEditHabitacion(hab.id)"
                                   >
-                                    Cancel
+                                    {{ t('common.cancel') }}
                                   </button>
                                 </div>
                               </td>
@@ -327,7 +345,7 @@
               <!-- Cancellation policy (visual only) -->
               <div class="mb-6">
                 <label class="block text-sm font-medium text-gray-700 mb-3"
-                  >Cancellation Policy</label
+                  >{{ t('rateManagement.cancellationPolicy') }}</label
                 >
                 <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
                   <button
@@ -346,8 +364,8 @@
                           : 'far fa-circle mr-2'
                       "
                     ></i>
-                    Flexible
-                    <p class="text-xs text-gray-600 mt-1">Free cancellation 24h before</p>
+                    {{ t('rateManagement.policy.flexible') }}
+                    <p class="text-xs text-gray-600 mt-1">{{ t('rateManagement.policy.flexibleDesc') }}</p>
                   </button>
                   <button
                     type="button"
@@ -365,8 +383,8 @@
                           : 'far fa-circle mr-2'
                       "
                     ></i>
-                    Moderate
-                    <p class="text-xs text-gray-600 mt-1">Free cancellation 7 days before</p>
+                    {{ t('rateManagement.policy.moderate') }}
+                    <p class="text-xs text-gray-600 mt-1">{{ t('rateManagement.policy.moderateDesc') }}</p>
                   </button>
                   <button
                     type="button"
@@ -384,8 +402,8 @@
                           : 'far fa-circle mr-2'
                       "
                     ></i>
-                    Strict
-                    <p class="text-xs text-gray-600 mt-1">Non-refundable</p>
+                    {{ t('rateManagement.policy.strict') }}
+                    <p class="text-xs text-gray-600 mt-1">{{ t('rateManagement.policy.strictDesc') }}</p>
                   </button>
                 </div>
               </div>
@@ -393,18 +411,18 @@
               <!-- Planes tarifarios -->
               <div class="border-t border-gray-100 pt-6">
                 <div class="flex items-center justify-between mb-4">
-                  <h4 class="text-sm font-semibold text-gray-900">Rate Plans</h4>
+                  <h4 class="text-sm font-semibold text-gray-900">{{ t('rateManagement.ratePlans') }}</h4>
                   <button
                     type="button"
                     class="px-3 py-1.5 bg-primary-600 text-white rounded-lg text-xs font-medium hover:bg-primary-700 transition-colors"
                     (click)="openAddPlanModal(tipo.id); $event.stopPropagation()"
                   >
-                    <i class="fas fa-plus mr-1"></i>Add Plan
+                    <i class="fas fa-plus mr-1"></i>{{ t('rateManagement.addPlan') }}
                   </button>
                 </div>
 
                 @if (getPlanesForTipo(tipo.id).length === 0) {
-                  <p class="text-sm text-gray-500 py-4">No rate plans yet. Add one above.</p>
+                  <p class="text-sm text-gray-500 py-4">{{ t('rateManagement.noRatePlans') }}</p>
                 }
 
                 @for (plan of getPlanesForTipo(tipo.id); track plan.id) {
@@ -436,29 +454,29 @@
                       <div class="p-4">
                         <div class="flex items-center justify-between mb-3">
                           <h5 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">
-                            Pricing Rules
+                            {{ t('rateManagement.plan.rules') }}
                           </h5>
                           <button
                             type="button"
                             class="px-3 py-1 bg-gray-100 text-gray-700 rounded-lg text-xs font-medium hover:bg-gray-200 transition-colors"
                             (click)="openAddReglaModal(plan.id)"
                           >
-                            <i class="fas fa-plus mr-1"></i>Add Rule
+                            <i class="fas fa-plus mr-1"></i>{{ t('rateManagement.addRule') }}
                           </button>
                         </div>
 
                         @if (getReglasForPlan(plan.id).length === 0) {
-                          <p class="text-xs text-gray-500 py-2">No pricing rules. Add one above.</p>
+                          <p class="text-xs text-gray-500 py-2">{{ t('rateManagement.plan.noRules') }}</p>
                         } @else {
                           <div class="overflow-x-auto">
                             <table class="w-full text-xs">
                               <thead>
                                 <tr class="text-left text-gray-500 border-b border-gray-100">
-                                  <th class="pb-2 pr-4 font-medium">Price/night</th>
-                                  <th class="pb-2 pr-4 font-medium">Date range</th>
-                                  <th class="pb-2 pr-4 font-medium">Min nights</th>
-                                  <th class="pb-2 pr-4 font-medium">Priority</th>
-                                  <th class="pb-2 font-medium">Actions</th>
+                                  <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.rule.basePriceLabel') }}</th>
+                                  <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.rule.dateRangeLabel') }}</th>
+                                  <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.rule.minNightsLabel') }}</th>
+                                  <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.rule.priorityLabel') }}</th>
+                                  <th class="pb-2 font-medium">{{ t('rateManagement.table.actions') }}</th>
                                 </tr>
                               </thead>
                               <tbody>
@@ -567,7 +585,7 @@
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
     <div class="bg-white rounded-2xl shadow-xl p-6 w-full max-w-md mx-4">
       <div class="flex items-center justify-between mb-6">
-        <h2 class="text-lg font-semibold text-gray-900">Add Room Type</h2>
+        <h2 class="text-lg font-semibold text-gray-900">{{ t('rateManagement.tipo.addTitle') }}</h2>
         <button
           type="button"
           class="text-gray-400 hover:text-gray-600"
@@ -578,26 +596,26 @@
       </div>
       <div class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('common.name') }} *</label>
           <input
             type="text"
             class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-            placeholder="e.g. Deluxe King Room"
+            [placeholder]="t('rateManagement.tipo.namePlaceholder')"
             [(ngModel)]="newTipo.nombre"
           />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Description</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.tipo.description') }}</label>
           <input
             type="text"
             class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-            placeholder="Optional description"
+            [placeholder]="t('rateManagement.tipo.optionalDesc')"
             [(ngModel)]="newTipo.descripcion"
           />
         </div>
         <div class="grid grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Capacity *</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.tipo.capacidad') }} *</label>
             <input
               type="number"
               min="1"
@@ -606,7 +624,7 @@
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Beds *</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.beds') }} *</label>
             <input
               type="number"
               min="1"
@@ -622,7 +640,7 @@
           class="px-5 py-2.5 bg-gray-100 text-gray-700 rounded-xl text-sm font-medium hover:bg-gray-200 transition-colors"
           (click)="showAddTipoModal.set(false)"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           type="button"
@@ -633,7 +651,7 @@
           @if (saving()) {
             <i class="fas fa-spinner fa-spin mr-2"></i>
           }
-          Save Room Type
+          {{ t('rateManagement.tipo.saveTipo') }}
         </button>
       </div>
     </div>
@@ -645,7 +663,7 @@
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
     <div class="bg-white rounded-2xl shadow-xl p-6 w-full max-w-md mx-4">
       <div class="flex items-center justify-between mb-6">
-        <h2 class="text-lg font-semibold text-gray-900">Add Rate Plan</h2>
+        <h2 class="text-lg font-semibold text-gray-900">{{ t('rateManagement.plan.addTitle') }}</h2>
         <button
           type="button"
           class="text-gray-400 hover:text-gray-600"
@@ -656,33 +674,29 @@
       </div>
       <div class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Plan Name *</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.plan.name') }} *</label>
           <input
             type="text"
             class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-            placeholder="e.g. Standard, Weekday Special"
+            [placeholder]="t('rateManagement.plan.namePlaceholder')"
             [(ngModel)]="newPlan.nombre"
           />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Description</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.plan.description') }}</label>
           <input
             type="text"
             class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-            placeholder="Optional"
+            [placeholder]="t('rateManagement.plan.descPlaceholder')"
             [(ngModel)]="newPlan.descripcion"
           />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Currency</label>
-          <select
-            class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-            [(ngModel)]="newPlan.moneda"
-          >
-            <option value="USD">USD</option>
-            <option value="EUR">EUR</option>
-            <option value="COP">COP</option>
-          </select>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.plan.currency') }}</label>
+          <div class="w-full px-4 py-2.5 border border-gray-200 rounded-xl text-sm bg-gray-50 text-gray-500 flex items-center gap-2">
+            <span class="font-medium text-gray-700">USD</span>
+            <span class="text-xs text-gray-400">{{ t('rateManagement.currencyNote') }}</span>
+          </div>
         </div>
       </div>
       <div class="flex justify-end space-x-3 mt-6">
@@ -691,7 +705,7 @@
           class="px-5 py-2.5 bg-gray-100 text-gray-700 rounded-xl text-sm font-medium hover:bg-gray-200 transition-colors"
           (click)="showAddPlanModal.set(false)"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           type="button"
@@ -702,7 +716,7 @@
           @if (saving()) {
             <i class="fas fa-spinner fa-spin mr-2"></i>
           }
-          Save Plan
+          {{ t('rateManagement.plan.saveTitle') }}
         </button>
       </div>
     </div>
@@ -714,7 +728,7 @@
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
     <div class="bg-white rounded-2xl shadow-xl p-6 w-full max-w-md mx-4">
       <div class="flex items-center justify-between mb-6">
-        <h2 class="text-lg font-semibold text-gray-900">Add Room</h2>
+        <h2 class="text-lg font-semibold text-gray-900">{{ t('rateManagement.room.addTitle') }}</h2>
         <button
           type="button"
           class="text-gray-400 hover:text-gray-600"
@@ -725,7 +739,7 @@
       </div>
       <div class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Room Number *</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.table.roomNumber') }} *</label>
           <input
             type="number"
             min="1"
@@ -736,7 +750,7 @@
         </div>
         <div class="grid grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Capacity *</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.table.capacity') }} *</label>
             <input
               type="number"
               min="1"
@@ -745,7 +759,7 @@
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Beds *</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.beds') }} *</label>
             <input
               type="number"
               min="1"
@@ -761,7 +775,7 @@
           class="px-5 py-2.5 bg-gray-100 text-gray-700 rounded-xl text-sm font-medium hover:bg-gray-200 transition-colors"
           (click)="showAddHabitacionModal.set(false)"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           type="button"
@@ -772,7 +786,7 @@
           @if (saving()) {
             <i class="fas fa-spinner fa-spin mr-2"></i>
           }
-          Save Room
+          {{ t('rateManagement.room.saveRoom') }}
         </button>
       </div>
     </div>
@@ -784,7 +798,7 @@
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
     <div class="bg-white rounded-2xl shadow-xl p-6 w-full max-w-md mx-4">
       <div class="flex items-center justify-between mb-6">
-        <h2 class="text-lg font-semibold text-gray-900">Add Pricing Rule</h2>
+        <h2 class="text-lg font-semibold text-gray-900">{{ t('rateManagement.rule.addTitle') }}</h2>
         <button
           type="button"
           class="text-gray-400 hover:text-gray-600"
@@ -796,7 +810,7 @@
       <div class="space-y-4">
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1"
-            >Base Price / Night ($) *</label
+            >{{ t('rateManagement.rule.basePriceLabel') }} *</label
           >
           <div class="relative">
             <span class="absolute left-4 top-1/2 -translate-y-1/2 text-gray-500">$</span>
@@ -811,7 +825,7 @@
         </div>
         <div class="grid grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Date From</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.rule.dateFromLabel') }}</label>
             <input
               type="date"
               class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -819,7 +833,7 @@
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Date To</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.rule.dateToLabel') }}</label>
             <input
               type="date"
               class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -829,7 +843,7 @@
         </div>
         <div class="grid grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Min Nights</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.rule.minNightsLabel') }}</label>
             <input
               type="number"
               min="1"
@@ -838,7 +852,7 @@
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Priority</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.rule.priorityLabel') }}</label>
             <input
               type="number"
               min="0"
@@ -854,7 +868,7 @@
           class="px-5 py-2.5 bg-gray-100 text-gray-700 rounded-xl text-sm font-medium hover:bg-gray-200 transition-colors"
           (click)="showAddReglaModal.set(false)"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           type="button"
@@ -865,7 +879,7 @@
           @if (saving()) {
             <i class="fas fa-spinner fa-spin mr-2"></i>
           }
-          Save Rule
+          {{ t('rateManagement.rule.saveRule') }}
         </button>
       </div>
     </div>

--- a/frontends/web-admin/src/app/features/private/pages/rate-management-page/rate-management-page.component.html
+++ b/frontends/web-admin/src/app/features/private/pages/rate-management-page/rate-management-page.component.html
@@ -23,18 +23,36 @@
             <button
               type="button"
               (click)="setLanguage('es')"
-              [class]="currentLanguage === 'es' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >ES</button>
+              [class]="
+                currentLanguage === 'es'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              ES
+            </button>
             <button
               type="button"
               (click)="setLanguage('en')"
-              [class]="currentLanguage === 'en' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >EN</button>
+              [class]="
+                currentLanguage === 'en'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              EN
+            </button>
             <button
               type="button"
               (click)="setLanguage('pt')"
-              [class]="currentLanguage === 'pt' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >PT</button>
+              [class]="
+                currentLanguage === 'pt'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              PT
+            </button>
           </div>
           <button
             class="relative p-2 text-gray-600 hover:text-primary-600 transition-colors"
@@ -158,7 +176,9 @@
       <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 mb-6">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
           <div class="flex-1 max-w-md">
-            <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('rateManagement.selectProperty') }}</label>
+            <label class="block text-sm font-medium text-gray-700 mb-2">{{
+              t('rateManagement.selectProperty')
+            }}</label>
             @if (loadingHotels()) {
               <div class="flex items-center text-sm text-gray-500">
                 <i class="fas fa-spinner fa-spin mr-2"></i>{{ t('rateManagement.loadingHotels') }}
@@ -255,9 +275,15 @@
                     <table class="w-full text-xs">
                       <thead>
                         <tr class="text-left text-gray-500 border-b border-gray-100">
-                          <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.table.roomNumber') }}</th>
-                          <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.table.capacity') }}</th>
-                          <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.table.beds') }}</th>
+                          <th class="pb-2 pr-4 font-medium">
+                            {{ t('rateManagement.table.roomNumber') }}
+                          </th>
+                          <th class="pb-2 pr-4 font-medium">
+                            {{ t('rateManagement.table.capacity') }}
+                          </th>
+                          <th class="pb-2 pr-4 font-medium">
+                            {{ t('rateManagement.table.beds') }}
+                          </th>
                           <th class="pb-2 font-medium">{{ t('rateManagement.table.actions') }}</th>
                         </tr>
                       </thead>
@@ -344,9 +370,9 @@
 
               <!-- Cancellation policy (visual only) -->
               <div class="mb-6">
-                <label class="block text-sm font-medium text-gray-700 mb-3"
-                  >{{ t('rateManagement.cancellationPolicy') }}</label
-                >
+                <label class="block text-sm font-medium text-gray-700 mb-3">{{
+                  t('rateManagement.cancellationPolicy')
+                }}</label>
                 <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
                   <button
                     type="button"
@@ -365,7 +391,9 @@
                       "
                     ></i>
                     {{ t('rateManagement.policy.flexible') }}
-                    <p class="text-xs text-gray-600 mt-1">{{ t('rateManagement.policy.flexibleDesc') }}</p>
+                    <p class="text-xs text-gray-600 mt-1">
+                      {{ t('rateManagement.policy.flexibleDesc') }}
+                    </p>
                   </button>
                   <button
                     type="button"
@@ -384,7 +412,9 @@
                       "
                     ></i>
                     {{ t('rateManagement.policy.moderate') }}
-                    <p class="text-xs text-gray-600 mt-1">{{ t('rateManagement.policy.moderateDesc') }}</p>
+                    <p class="text-xs text-gray-600 mt-1">
+                      {{ t('rateManagement.policy.moderateDesc') }}
+                    </p>
                   </button>
                   <button
                     type="button"
@@ -403,7 +433,9 @@
                       "
                     ></i>
                     {{ t('rateManagement.policy.strict') }}
-                    <p class="text-xs text-gray-600 mt-1">{{ t('rateManagement.policy.strictDesc') }}</p>
+                    <p class="text-xs text-gray-600 mt-1">
+                      {{ t('rateManagement.policy.strictDesc') }}
+                    </p>
                   </button>
                 </div>
               </div>
@@ -411,7 +443,9 @@
               <!-- Planes tarifarios -->
               <div class="border-t border-gray-100 pt-6">
                 <div class="flex items-center justify-between mb-4">
-                  <h4 class="text-sm font-semibold text-gray-900">{{ t('rateManagement.ratePlans') }}</h4>
+                  <h4 class="text-sm font-semibold text-gray-900">
+                    {{ t('rateManagement.ratePlans') }}
+                  </h4>
                   <button
                     type="button"
                     class="px-3 py-1.5 bg-primary-600 text-white rounded-lg text-xs font-medium hover:bg-primary-700 transition-colors"
@@ -466,17 +500,29 @@
                         </div>
 
                         @if (getReglasForPlan(plan.id).length === 0) {
-                          <p class="text-xs text-gray-500 py-2">{{ t('rateManagement.plan.noRules') }}</p>
+                          <p class="text-xs text-gray-500 py-2">
+                            {{ t('rateManagement.plan.noRules') }}
+                          </p>
                         } @else {
                           <div class="overflow-x-auto">
                             <table class="w-full text-xs">
                               <thead>
                                 <tr class="text-left text-gray-500 border-b border-gray-100">
-                                  <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.rule.basePriceLabel') }}</th>
-                                  <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.rule.dateRangeLabel') }}</th>
-                                  <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.rule.minNightsLabel') }}</th>
-                                  <th class="pb-2 pr-4 font-medium">{{ t('rateManagement.rule.priorityLabel') }}</th>
-                                  <th class="pb-2 font-medium">{{ t('rateManagement.table.actions') }}</th>
+                                  <th class="pb-2 pr-4 font-medium">
+                                    {{ t('rateManagement.rule.basePriceLabel') }}
+                                  </th>
+                                  <th class="pb-2 pr-4 font-medium">
+                                    {{ t('rateManagement.rule.dateRangeLabel') }}
+                                  </th>
+                                  <th class="pb-2 pr-4 font-medium">
+                                    {{ t('rateManagement.rule.minNightsLabel') }}
+                                  </th>
+                                  <th class="pb-2 pr-4 font-medium">
+                                    {{ t('rateManagement.rule.priorityLabel') }}
+                                  </th>
+                                  <th class="pb-2 font-medium">
+                                    {{ t('rateManagement.table.actions') }}
+                                  </th>
                                 </tr>
                               </thead>
                               <tbody>
@@ -596,7 +642,9 @@
       </div>
       <div class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('common.name') }} *</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1"
+            >{{ t('common.name') }} *</label
+          >
           <input
             type="text"
             class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -605,7 +653,9 @@
           />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.tipo.description') }}</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            t('rateManagement.tipo.description')
+          }}</label>
           <input
             type="text"
             class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -615,7 +665,9 @@
         </div>
         <div class="grid grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.tipo.capacidad') }} *</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1"
+              >{{ t('rateManagement.tipo.capacidad') }} *</label
+            >
             <input
               type="number"
               min="1"
@@ -624,7 +676,9 @@
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.beds') }} *</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1"
+              >{{ t('rateManagement.beds') }} *</label
+            >
             <input
               type="number"
               min="1"
@@ -674,7 +728,9 @@
       </div>
       <div class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.plan.name') }} *</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1"
+            >{{ t('rateManagement.plan.name') }} *</label
+          >
           <input
             type="text"
             class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -683,7 +739,9 @@
           />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.plan.description') }}</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            t('rateManagement.plan.description')
+          }}</label>
           <input
             type="text"
             class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -692,8 +750,12 @@
           />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.plan.currency') }}</label>
-          <div class="w-full px-4 py-2.5 border border-gray-200 rounded-xl text-sm bg-gray-50 text-gray-500 flex items-center gap-2">
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            t('rateManagement.plan.currency')
+          }}</label>
+          <div
+            class="w-full px-4 py-2.5 border border-gray-200 rounded-xl text-sm bg-gray-50 text-gray-500 flex items-center gap-2"
+          >
             <span class="font-medium text-gray-700">USD</span>
             <span class="text-xs text-gray-400">{{ t('rateManagement.currencyNote') }}</span>
           </div>
@@ -739,7 +801,9 @@
       </div>
       <div class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.table.roomNumber') }} *</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1"
+            >{{ t('rateManagement.table.roomNumber') }} *</label
+          >
           <input
             type="number"
             min="1"
@@ -750,7 +814,9 @@
         </div>
         <div class="grid grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.table.capacity') }} *</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1"
+              >{{ t('rateManagement.table.capacity') }} *</label
+            >
             <input
               type="number"
               min="1"
@@ -759,7 +825,9 @@
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.beds') }} *</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1"
+              >{{ t('rateManagement.beds') }} *</label
+            >
             <input
               type="number"
               min="1"
@@ -825,7 +893,9 @@
         </div>
         <div class="grid grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.rule.dateFromLabel') }}</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{
+              t('rateManagement.rule.dateFromLabel')
+            }}</label>
             <input
               type="date"
               class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -833,7 +903,9 @@
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.rule.dateToLabel') }}</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{
+              t('rateManagement.rule.dateToLabel')
+            }}</label>
             <input
               type="date"
               class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -843,7 +915,9 @@
         </div>
         <div class="grid grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.rule.minNightsLabel') }}</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{
+              t('rateManagement.rule.minNightsLabel')
+            }}</label>
             <input
               type="number"
               min="1"
@@ -852,7 +926,9 @@
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('rateManagement.rule.priorityLabel') }}</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{
+              t('rateManagement.rule.priorityLabel')
+            }}</label>
             <input
               type="number"
               min="0"

--- a/frontends/web-admin/src/app/features/private/pages/rate-management-page/rate-management-page.component.ts
+++ b/frontends/web-admin/src/app/features/private/pages/rate-management-page/rate-management-page.component.ts
@@ -5,6 +5,8 @@ import { Router, RouterModule } from '@angular/router';
 
 import { AuthService } from '../../../../core/services/auth.service';
 import { RateManagementService } from '../../../../core/services/rate-management.service';
+import { I18nService } from '../../../../core/services/i18n.service';
+import { LanguageCode } from '../../../../core/i18n/translations';
 import {
   CreateHabitacionRequest,
   CreatePlanTarifarioRequest,
@@ -27,6 +29,7 @@ export class RateManagementPageComponent implements OnInit {
   private readonly authService = inject(AuthService);
   private readonly rateService = inject(RateManagementService);
   private readonly router = inject(Router);
+  private readonly i18nService = inject(I18nService);
 
   readonly currentUser = this.authService.currentUser;
 
@@ -420,6 +423,18 @@ export class RateManagementPageComponent implements OnInit {
   logout(): void {
     this.authService.clearSession();
     this.router.navigate(['/login']);
+  }
+
+  t(key: Parameters<I18nService['t']>[0]): string {
+    return this.i18nService.t(key);
+  }
+
+  get currentLanguage() {
+    return this.i18nService.currentLanguage();
+  }
+
+  setLanguage(lang: LanguageCode): void {
+    this.i18nService.setLanguage(lang);
   }
 
   getSelectedHotel(): Hotel | undefined {

--- a/frontends/web-admin/src/app/features/private/pages/reservations-page/reservations-page.component.html
+++ b/frontends/web-admin/src/app/features/private/pages/reservations-page/reservations-page.component.html
@@ -20,18 +20,36 @@
             <button
               type="button"
               (click)="setLanguage('es')"
-              [class]="currentLanguage === 'es' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >ES</button>
+              [class]="
+                currentLanguage === 'es'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              ES
+            </button>
             <button
               type="button"
               (click)="setLanguage('en')"
-              [class]="currentLanguage === 'en' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >EN</button>
+              [class]="
+                currentLanguage === 'en'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              EN
+            </button>
             <button
               type="button"
               (click)="setLanguage('pt')"
-              [class]="currentLanguage === 'pt' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
-            >PT</button>
+              [class]="
+                currentLanguage === 'pt'
+                  ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300'
+                  : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'
+              "
+            >
+              PT
+            </button>
           </div>
           <button
             class="relative p-2 text-gray-600 hover:text-primary-600 transition-colors"
@@ -123,7 +141,9 @@
       <div class="mb-8">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">{{ t('reservations.title') }}</h1>
+            <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
+              {{ t('reservations.title') }}
+            </h1>
             <p class="text-gray-600 text-sm">{{ t('reservations.subtitle') }}</p>
           </div>
           <div class="mt-4 sm:mt-0 flex items-center space-x-3">
@@ -159,7 +179,9 @@
         <form [formGroup]="filterForm" (ngSubmit)="applyFilters()">
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 gap-4">
             <div class="col-span-1">
-              <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('reservations.filter.bookingCode') }}</label>
+              <label class="block text-sm font-medium text-gray-700 mb-2">{{
+                t('reservations.filter.bookingCode')
+              }}</label>
               <div class="relative">
                 <input
                   type="text"
@@ -172,7 +194,9 @@
             </div>
 
             <div class="col-span-1">
-              <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('reservations.filter.checkInFrom') }}</label>
+              <label class="block text-sm font-medium text-gray-700 mb-2">{{
+                t('reservations.filter.checkInFrom')
+              }}</label>
               <input
                 type="date"
                 formControlName="fecha_desde"
@@ -181,7 +205,9 @@
             </div>
 
             <div class="col-span-1">
-              <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('reservations.filter.checkInTo') }}</label>
+              <label class="block text-sm font-medium text-gray-700 mb-2">{{
+                t('reservations.filter.checkInTo')
+              }}</label>
               <input
                 type="date"
                 formControlName="fecha_hasta"
@@ -190,7 +216,9 @@
             </div>
 
             <div class="col-span-1">
-              <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('reservations.filter.status') }}</label>
+              <label class="block text-sm font-medium text-gray-700 mb-2">{{
+                t('reservations.filter.status')
+              }}</label>
               <select
                 formControlName="id_estado"
                 class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -201,7 +229,9 @@
             </div>
 
             <div class="col-span-1">
-              <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('reservations.filter.roomType') }}</label>
+              <label class="block text-sm font-medium text-gray-700 mb-2">{{
+                t('reservations.filter.roomType')
+              }}</label>
               <input
                 type="text"
                 formControlName="tipo_habitacion"
@@ -239,7 +269,9 @@
               <i class="fas fa-calendar-check text-primary-600 text-xl"></i>
             </div>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('reservations.stats.total') }}</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">
+            {{ t('reservations.stats.total') }}
+          </h3>
           <p class="text-3xl font-bold text-gray-900">
             <span *ngIf="loading"><i class="fas fa-spinner fa-spin text-gray-400"></i></span>
             <span *ngIf="!loading">{{ stats.total | number }}</span>
@@ -252,7 +284,9 @@
               <i class="fas fa-check-circle text-green-600 text-xl"></i>
             </div>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('reservations.stats.confirmed') }}</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">
+            {{ t('reservations.stats.confirmed') }}
+          </h3>
           <p class="text-3xl font-bold text-gray-900">
             <span *ngIf="loading"><i class="fas fa-spinner fa-spin text-gray-400"></i></span>
             <span *ngIf="!loading">{{ stats.confirmadas | number }}</span>
@@ -265,7 +299,9 @@
               <i class="fas fa-clock text-orange-600 text-xl"></i>
             </div>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('reservations.stats.pending') }}</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">
+            {{ t('reservations.stats.pending') }}
+          </h3>
           <p class="text-3xl font-bold text-gray-900">
             <span *ngIf="loading"><i class="fas fa-spinner fa-spin text-gray-400"></i></span>
             <span *ngIf="!loading">{{ stats.pendientes | number }}</span>
@@ -278,7 +314,9 @@
               <i class="fas fa-times-circle text-red-600 text-xl"></i>
             </div>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('reservations.stats.cancelledRejected') }}</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">
+            {{ t('reservations.stats.cancelledRejected') }}
+          </h3>
           <p class="text-3xl font-bold text-gray-900">
             <span *ngIf="loading"><i class="fas fa-spinner fa-spin text-gray-400"></i></span>
             <span *ngIf="!loading">{{ stats.canceladas + stats.rechazadas | number }}</span>
@@ -291,7 +329,9 @@
         <div class="p-6 border-b border-gray-100">
           <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h2 class="text-xl font-bold text-gray-900 mb-1">{{ t('reservations.list.title') }}</h2>
+              <h2 class="text-xl font-bold text-gray-900 mb-1">
+                {{ t('reservations.list.title') }}
+              </h2>
               <p class="text-sm text-gray-600">{{ t('reservations.list.subtitle') }}</p>
             </div>
             <div class="mt-4 sm:mt-0 flex items-center space-x-3">
@@ -450,8 +490,10 @@
         <div *ngIf="!loading && pages > 0" class="p-6 border-t border-gray-100">
           <div class="flex flex-col sm:flex-row items-center justify-between">
             <p class="text-sm text-gray-600 mb-4 sm:mb-0">
-              {{ t('reservations.pagination.showing') }} {{ showingFrom | number }} {{ t('reservations.pagination.to') }} {{ showingTo | number }} {{ t('reservations.pagination.of') }}
-              {{ total | number }} {{ t('reservations.pagination.results') }}
+              {{ t('reservations.pagination.showing') }} {{ showingFrom | number }}
+              {{ t('reservations.pagination.to') }} {{ showingTo | number }}
+              {{ t('reservations.pagination.of') }} {{ total | number }}
+              {{ t('reservations.pagination.results') }}
             </p>
             <div class="flex items-center space-x-2">
               <button

--- a/frontends/web-admin/src/app/features/private/pages/reservations-page/reservations-page.component.html
+++ b/frontends/web-admin/src/app/features/private/pages/reservations-page/reservations-page.component.html
@@ -15,6 +15,24 @@
           </div>
         </div>
         <div class="flex items-center space-x-4">
+          <!-- Language selector -->
+          <div class="flex items-center gap-1">
+            <button
+              type="button"
+              (click)="setLanguage('es')"
+              [class]="currentLanguage === 'es' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >ES</button>
+            <button
+              type="button"
+              (click)="setLanguage('en')"
+              [class]="currentLanguage === 'en' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >EN</button>
+            <button
+              type="button"
+              (click)="setLanguage('pt')"
+              [class]="currentLanguage === 'pt' ? 'px-2 py-1 text-xs font-semibold bg-primary-100 text-primary-700 rounded-md border border-primary-300' : 'px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100'"
+            >PT</button>
+          </div>
           <button
             class="relative p-2 text-gray-600 hover:text-primary-600 transition-colors"
             type="button"
@@ -49,42 +67,42 @@
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
           <i class="fas fa-chart-line w-5 mr-3"></i>
-          Dashboard
+          {{ t('sidebar.dashboard') }}
         </a>
         <a
           [routerLink]="['/reservations']"
           class="flex items-center px-4 py-3 text-sm font-medium text-white bg-primary-600 rounded-xl transition-colors"
         >
           <i class="fas fa-calendar-check w-5 mr-3"></i>
-          Reservations
+          {{ t('sidebar.reservations') }}
         </a>
         <a
           href="#"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
           <i class="fas fa-hotel w-5 mr-3"></i>
-          Properties
+          {{ t('sidebar.properties') }}
         </a>
         <a
           href="#"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
           <i class="fas fa-users w-5 mr-3"></i>
-          Guests
+          {{ t('sidebar.guests') }}
         </a>
         <a
           href="#"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
           <i class="fas fa-dollar-sign w-5 mr-3"></i>
-          Revenue
+          {{ t('sidebar.revenue') }}
         </a>
         <a
           [routerLink]="['/room-rate-management']"
           class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
         >
           <i class="fas fa-cog w-5 mr-3"></i>
-          Settings
+          {{ t('sidebar.settings') }}
         </a>
         <div class="pt-4 mt-4 border-t border-gray-100">
           <button
@@ -93,7 +111,7 @@
             (click)="logout()"
           >
             <i class="fas fa-sign-out-alt w-5 mr-3"></i>
-            Logout
+            {{ t('common.logout') }}
           </button>
         </div>
       </nav>
@@ -105,8 +123,8 @@
       <div class="mb-8">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">All Reservations</h1>
-            <p class="text-gray-600 text-sm">Manage and monitor all hotel reservations</p>
+            <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">{{ t('reservations.title') }}</h1>
+            <p class="text-gray-600 text-sm">{{ t('reservations.subtitle') }}</p>
           </div>
           <div class="mt-4 sm:mt-0 flex items-center space-x-3">
             <button
@@ -114,7 +132,7 @@
               type="button"
             >
               <i class="fas fa-download mr-2"></i>
-              Export
+              {{ t('common.export') }}
             </button>
           </div>
         </div>
@@ -132,7 +150,7 @@
           class="ml-auto text-red-500 hover:text-red-700"
           (click)="loadDashboard()"
         >
-          <i class="fas fa-redo"></i> Retry
+          <i class="fas fa-redo"></i> {{ t('common.retry') }}
         </button>
       </div>
 
@@ -141,12 +159,12 @@
         <form [formGroup]="filterForm" (ngSubmit)="applyFilters()">
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 gap-4">
             <div class="col-span-1">
-              <label class="block text-sm font-medium text-gray-700 mb-2">Booking Code</label>
+              <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('reservations.filter.bookingCode') }}</label>
               <div class="relative">
                 <input
                   type="text"
                   formControlName="codigo"
-                  placeholder="Search code..."
+                  [placeholder]="t('reservations.filter.searchCode')"
                   class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                 />
                 <i class="fas fa-search absolute right-3 top-3 text-gray-400 text-sm"></i>
@@ -154,7 +172,7 @@
             </div>
 
             <div class="col-span-1">
-              <label class="block text-sm font-medium text-gray-700 mb-2">Check-in From</label>
+              <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('reservations.filter.checkInFrom') }}</label>
               <input
                 type="date"
                 formControlName="fecha_desde"
@@ -163,7 +181,7 @@
             </div>
 
             <div class="col-span-1">
-              <label class="block text-sm font-medium text-gray-700 mb-2">Check-in To</label>
+              <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('reservations.filter.checkInTo') }}</label>
               <input
                 type="date"
                 formControlName="fecha_hasta"
@@ -172,22 +190,22 @@
             </div>
 
             <div class="col-span-1">
-              <label class="block text-sm font-medium text-gray-700 mb-2">Status</label>
+              <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('reservations.filter.status') }}</label>
               <select
                 formControlName="id_estado"
                 class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
               >
-                <option value="">All Status</option>
+                <option value="">{{ t('reservations.filter.allStatus') }}</option>
                 <option *ngFor="let e of estados" [value]="e.id">{{ e.nombre }}</option>
               </select>
             </div>
 
             <div class="col-span-1">
-              <label class="block text-sm font-medium text-gray-700 mb-2">Room Type</label>
+              <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('reservations.filter.roomType') }}</label>
               <input
                 type="text"
                 formControlName="tipo_habitacion"
-                placeholder="e.g. Suite"
+                [placeholder]="t('reservations.filter.roomTypePlaceholder')"
                 class="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
               />
             </div>
@@ -198,13 +216,13 @@
                 class="flex-1 px-4 py-2.5 bg-primary-600 text-white rounded-xl text-sm font-medium hover:bg-primary-700 transition-colors"
               >
                 <i class="fas fa-filter mr-2"></i>
-                Filter
+                {{ t('common.filter') }}
               </button>
               <button
                 type="button"
                 class="px-3 py-2.5 border border-gray-300 text-gray-600 rounded-xl text-sm hover:bg-gray-50 transition-colors"
                 (click)="clearFilters()"
-                title="Clear filters"
+                [title]="t('common.clearFilters')"
               >
                 <i class="fas fa-times"></i>
               </button>
@@ -221,7 +239,7 @@
               <i class="fas fa-calendar-check text-primary-600 text-xl"></i>
             </div>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">Total Reservations</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('reservations.stats.total') }}</h3>
           <p class="text-3xl font-bold text-gray-900">
             <span *ngIf="loading"><i class="fas fa-spinner fa-spin text-gray-400"></i></span>
             <span *ngIf="!loading">{{ stats.total | number }}</span>
@@ -234,7 +252,7 @@
               <i class="fas fa-check-circle text-green-600 text-xl"></i>
             </div>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">Confirmed</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('reservations.stats.confirmed') }}</h3>
           <p class="text-3xl font-bold text-gray-900">
             <span *ngIf="loading"><i class="fas fa-spinner fa-spin text-gray-400"></i></span>
             <span *ngIf="!loading">{{ stats.confirmadas | number }}</span>
@@ -247,7 +265,7 @@
               <i class="fas fa-clock text-orange-600 text-xl"></i>
             </div>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">Pending</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('reservations.stats.pending') }}</h3>
           <p class="text-3xl font-bold text-gray-900">
             <span *ngIf="loading"><i class="fas fa-spinner fa-spin text-gray-400"></i></span>
             <span *ngIf="!loading">{{ stats.pendientes | number }}</span>
@@ -260,7 +278,7 @@
               <i class="fas fa-times-circle text-red-600 text-xl"></i>
             </div>
           </div>
-          <h3 class="text-gray-600 text-sm font-medium mb-1">Cancelled / Rejected</h3>
+          <h3 class="text-gray-600 text-sm font-medium mb-1">{{ t('reservations.stats.cancelledRejected') }}</h3>
           <p class="text-3xl font-bold text-gray-900">
             <span *ngIf="loading"><i class="fas fa-spinner fa-spin text-gray-400"></i></span>
             <span *ngIf="!loading">{{ stats.canceladas + stats.rechazadas | number }}</span>
@@ -273,8 +291,8 @@
         <div class="p-6 border-b border-gray-100">
           <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h2 class="text-xl font-bold text-gray-900 mb-1">Reservations List</h2>
-              <p class="text-sm text-gray-600">Complete list of all reservations</p>
+              <h2 class="text-xl font-bold text-gray-900 mb-1">{{ t('reservations.list.title') }}</h2>
+              <p class="text-sm text-gray-600">{{ t('reservations.list.subtitle') }}</p>
             </div>
             <div class="mt-4 sm:mt-0 flex items-center space-x-3">
               <select
@@ -285,9 +303,9 @@
                 "
                 class="px-3 py-2 border border-gray-300 rounded-lg text-sm"
               >
-                <option [value]="25">25 per page</option>
-                <option [value]="50">50 per page</option>
-                <option [value]="100">100 per page</option>
+                <option [value]="25">25 {{ t('reservations.perPage') }}</option>
+                <option [value]="50">50 {{ t('reservations.perPage') }}</option>
+                <option [value]="100">100 {{ t('reservations.perPage') }}</option>
               </select>
             </div>
           </div>
@@ -296,7 +314,7 @@
         <!-- Loading overlay skeleton -->
         <div *ngIf="loading" class="p-8 text-center text-gray-400">
           <i class="fas fa-spinner fa-spin text-3xl mb-3"></i>
-          <p class="text-sm">Loading reservations…</p>
+          <p class="text-sm">{{ t('reservations.list.loading') }}</p>
         </div>
 
         <!-- Empty state -->
@@ -306,8 +324,8 @@
           >
             <i class="fas fa-calendar-times text-gray-400 text-2xl"></i>
           </div>
-          <h3 class="text-gray-700 font-semibold mb-1">No reservations found</h3>
-          <p class="text-gray-500 text-sm">Try adjusting your filters or check back later.</p>
+          <h3 class="text-gray-700 font-semibold mb-1">{{ t('reservations.list.noFound') }}</h3>
+          <p class="text-gray-500 text-sm">{{ t('reservations.list.noFoundHint') }}</p>
         </div>
 
         <!-- Table -->
@@ -318,42 +336,42 @@
                 <th
                   class="text-left py-4 px-6 text-xs font-semibold text-gray-600 uppercase tracking-wider"
                 >
-                  ID
+                  {{ t('reservations.table.id') }}
                 </th>
                 <th
                   class="text-left py-4 px-6 text-xs font-semibold text-gray-600 uppercase tracking-wider"
                 >
-                  Guest ID
+                  {{ t('reservations.table.guestId') }}
                 </th>
                 <th
                   class="text-left py-4 px-6 text-xs font-semibold text-gray-600 uppercase tracking-wider hidden lg:table-cell"
                 >
-                  Property
+                  {{ t('reservations.table.property') }}
                 </th>
                 <th
                   class="text-left py-4 px-6 text-xs font-semibold text-gray-600 uppercase tracking-wider"
                 >
-                  Check-in
+                  {{ t('reservations.table.checkIn') }}
                 </th>
                 <th
                   class="text-left py-4 px-6 text-xs font-semibold text-gray-600 uppercase tracking-wider hidden md:table-cell"
                 >
-                  Check-out
+                  {{ t('reservations.table.checkOut') }}
                 </th>
                 <th
                   class="text-left py-4 px-6 text-xs font-semibold text-gray-600 uppercase tracking-wider hidden sm:table-cell"
                 >
-                  Nights
+                  {{ t('reservations.table.nights') }}
                 </th>
                 <th
                   class="text-left py-4 px-6 text-xs font-semibold text-gray-600 uppercase tracking-wider"
                 >
-                  Amount
+                  {{ t('reservations.table.amount') }}
                 </th>
                 <th
                   class="text-left py-4 px-6 text-xs font-semibold text-gray-600 uppercase tracking-wider"
                 >
-                  Status
+                  {{ t('reservations.table.status') }}
                 </th>
               </tr>
             </thead>
@@ -432,8 +450,8 @@
         <div *ngIf="!loading && pages > 0" class="p-6 border-t border-gray-100">
           <div class="flex flex-col sm:flex-row items-center justify-between">
             <p class="text-sm text-gray-600 mb-4 sm:mb-0">
-              Showing {{ showingFrom | number }} to {{ showingTo | number }} of
-              {{ total | number }} reservations
+              {{ t('reservations.pagination.showing') }} {{ showingFrom | number }} {{ t('reservations.pagination.to') }} {{ showingTo | number }} {{ t('reservations.pagination.of') }}
+              {{ total | number }} {{ t('reservations.pagination.results') }}
             </p>
             <div class="flex items-center space-x-2">
               <button

--- a/frontends/web-admin/src/app/features/private/pages/reservations-page/reservations-page.component.ts
+++ b/frontends/web-admin/src/app/features/private/pages/reservations-page/reservations-page.component.ts
@@ -11,6 +11,8 @@ import {
   ReservationItem,
   ReservationStats,
 } from '../../../../core/models/reservations.models';
+import { I18nService } from '../../../../core/services/i18n.service';
+import { LanguageCode } from '../../../../core/i18n/translations';
 
 @Component({
   selector: 'app-reservations-page',
@@ -47,6 +49,7 @@ export class ReservationsPageComponent implements OnInit {
     private readonly authService: AuthService,
     private readonly router: Router,
     private readonly cdr: ChangeDetectorRef,
+    readonly i18n: I18nService,
   ) {
     this.filterForm = this.fb.group({
       codigo: [''],
@@ -68,6 +71,18 @@ export class ReservationsPageComponent implements OnInit {
 
   currentUser() {
     return this.authService.currentUser();
+  }
+
+  t(key: Parameters<I18nService['t']>[0]): string {
+    return this.i18n.t(key);
+  }
+
+  get currentLanguage() {
+    return this.i18n.currentLanguage();
+  }
+
+  setLanguage(lang: LanguageCode): void {
+    this.i18n.setLanguage(lang);
   }
 
   loadDashboard(resetPage = false): void {


### PR DESCRIPTION
This pull request introduces a language internationalization (i18n) system to the web admin frontend, enabling support for English, Spanish, and Portuguese. It refactors the login and dashboard pages to use translation keys instead of hardcoded text, and adds a language selector to both pages for runtime language switching. The i18n service persists the user's language preference using local storage.

Key changes:

**Internationalization Infrastructure:**

* Added a new `I18nService` (`i18n.service.ts`) that provides translation lookup, language switching, and persistence of language preference in local storage. It exposes a reactive signal for the current language and a `t()` function for translation.

**Login Page Refactor:**

* Replaced all hardcoded UI text in `login-page.component.html` with translation keys accessed via the new `t()` method, including form labels, placeholders, button text, and help links. [[1]](diffhunk://#diff-3c7abbd0df9c3b3cb3d10c23907639c01c30b827b41d6b7cc73d1959f779bef7L45-R89) [[2]](diffhunk://#diff-3c7abbd0df9c3b3cb3d10c23907639c01c30b827b41d6b7cc73d1959f779bef7L63-R109) [[3]](diffhunk://#diff-3c7abbd0df9c3b3cb3d10c23907639c01c30b827b41d6b7cc73d1959f779bef7L83-R119) [[4]](diffhunk://#diff-3c7abbd0df9c3b3cb3d10c23907639c01c30b827b41d6b7cc73d1959f779bef7L104-R142) [[5]](diffhunk://#diff-3c7abbd0df9c3b3cb3d10c23907639c01c30b827b41d6b7cc73d1959f779bef7L122-R158) [[6]](diffhunk://#diff-3c7abbd0df9c3b3cb3d10c23907639c01c30b827b41d6b7cc73d1959f779bef7L136-R180) [[7]](diffhunk://#diff-3c7abbd0df9c3b3cb3d10c23907639c01c30b827b41d6b7cc73d1959f779bef7L160-R196)
* Added a language selector UI to the login page, allowing users to switch between English, Spanish, and Portuguese. The selected language is highlighted.
* Updated the login page component (`login-page.component.ts`) to inject the `I18nService`, expose the current language, and provide language switching and translation methods for the template. [[1]](diffhunk://#diff-3be0fc28fa5336f5975db8274a583e30ab9b5f68e38abb2b863bc3cd55ea6b7aR8-R9) [[2]](diffhunk://#diff-3be0fc28fa5336f5975db8274a583e30ab9b5f68e38abb2b863bc3cd55ea6b7aR33) [[3]](diffhunk://#diff-3be0fc28fa5336f5975db8274a583e30ab9b5f68e38abb2b863bc3cd55ea6b7aR111-R122)

**Dashboard Page Refactor:**

* Replaced all sidebar, header, KPI, and button text in `dashboard-page.component.html` with translation keys using the `t()` method for dynamic translation. [[1]](diffhunk://#diff-c284df8d682d875a87e6f4d2785d74a79d6af85d4f195923f748d49faf58d583L53-R124) [[2]](diffhunk://#diff-c284df8d682d875a87e6f4d2785d74a79d6af85d4f195923f748d49faf58d583L97-R133) [[3]](diffhunk://#diff-c284df8d682d875a87e6f4d2785d74a79d6af85d4f195923f748d49faf58d583L107-R162) [[4]](diffhunk://#diff-c284df8d682d875a87e6f4d2785d74a79d6af85d4f195923f748d49faf58d583L146-R188) [[5]](diffhunk://#diff-c284df8d682d875a87e6f4d2785d74a79d6af85d4f195923f748d49faf58d583L163-R207) [[6]](diffhunk://#diff-c284df8d682d875a87e6f4d2785d74a79d6af85d4f195923f748d49faf58d583L180-R226) [[7]](diffhunk://#diff-c284df8d682d875a87e6f4d2785d74a79d6af85d4f195923f748d49faf58d583L193-R245)
* Added a language selector UI to the dashboard page, mirroring the login page selector for consistency and global language switching.