### PR TITLE
Feature/hu p 21 loginadmin

### DIFF
--- a/frontends/web-admin/package.json
+++ b/frontends/web-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-admin",
-  "version": "0.0.0",
+  "version": "0.2.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 4201",

--- a/frontends/web-admin/src/app/features/private/pages/dashboard-page/dashboard-page.component.html
+++ b/frontends/web-admin/src/app/features/private/pages/dashboard-page/dashboard-page.component.html
@@ -386,6 +386,7 @@
       <div class="flex flex-col sm:flex-row justify-between items-center">
         <div class="flex items-center mb-4 sm:mb-0">
           <p class="text-sm text-gray-500">{{ t('footer.copyright') }}</p>
+          <p class="mt-1 text-[10px] leading-none text-gray-400">v0.2.1 · Sprint 2</p>
         </div>
         <div class="flex items-center space-x-6">
           <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors">{{

--- a/frontends/web-client/package.json
+++ b/frontends/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-client",
-  "version": "0.0.0",
+  "version": "0.2.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/frontends/web-client/src/app/shared/components/public-footer/public-footer.component.html
+++ b/frontends/web-client/src/app/shared/components/public-footer/public-footer.component.html
@@ -56,7 +56,7 @@
 
     <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
       <p>{{ t('footer.copyright') }}</p>
-      <p class="mt-2 text-[10px] leading-none text-gray-500">v0.1.0 · Sprint 1</p>
+      <p class="mt-2 text-[10px] leading-none text-gray-500">v0.2.1 · Sprint 2</p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
This pull request updates the versioning for both the `web-admin` and `web-client` frontends to `v0.2.1` and updates the displayed version and sprint information in the UI footers to reflect the new release.

Version and UI updates:

* Updated the `version` field in `package.json` for both `web-admin` and `web-client` to `0.2.1`. [[1]](diffhunk://#diff-4f321b6dec768267621726291c8a1160b814e63b756e96fa34281beae3fab822L3-R3) [[2]](diffhunk://#diff-2af7a43d3e9571b9d82f23c8b12bd90885a11a044258975c7f81a1fc3ca24a37L3-R3)
* Updated the footer in `web-client` to display `v0.2.1 · Sprint 2` instead of the previous version and sprint.
* Added a version and sprint label (`v0.2.1 · Sprint 2`) to the footer in the `web-admin` dashboard page.