### PR TITLE
feat: update webhook URL for pagos service and enhance SSL handling i…

### DIFF
--- a/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.html
+++ b/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.html
@@ -173,13 +173,6 @@
                   t('login.rememberMe')
                 }}</label>
               </div>
-              <div class="text-sm">
-                <a
-                  [routerLink]="['/setup-admin']"
-                  class="font-medium text-primary-600 hover:text-primary-500 transition-colors"
-                  >{{ t('login.setupAdmin') }}</a
-                >
-              </div>
             </div>
 
             <div id="submit-section">

--- a/infra/aws/terraform/taskdefs/pagos.json.tpl
+++ b/infra/aws/terraform/taskdefs/pagos.json.tpl
@@ -25,7 +25,7 @@
       "environment": [
         { "name": "FLASK_ENV", "value": "production" },
         { "name": "EXT_PAYMENTS_URL", "value": "http://__PUBLIC_ALB_DNS__/ext-payments" },
-        { "name": "PAGOS_WEBHOOK_URL", "value": "http://__PUBLIC_ALB_DNS__" },
+        { "name": "PAGOS_WEBHOOK_URL", "value": "http://__INTERNAL_ALB_DNS__:5002" },
         { "name": "MQ_HOST", "value": "__MQ_HOST__" },
         { "name": "MQ_PORT", "value": "__MQ_PORT__" },
         { "name": "MQ_USE_SSL", "value": "true" },

--- a/microservices/pagos/app/infrastructure/messaging/publisher.py
+++ b/microservices/pagos/app/infrastructure/messaging/publisher.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import ssl
 import stomp
 from typing import Optional
 from flask import current_app
@@ -46,6 +47,8 @@ class MessagePublisher:
                 ssl_options = {'for_hosts': [(self.host, self.port)]}
                 if self.ca_cert_path:
                     ssl_options['ca_certs'] = self.ca_cert_path
+                else:
+                    ssl_options['cert_reqs'] = ssl.CERT_NONE
                 self._connection.set_ssl(**ssl_options)
             self._connection.connect(self.username, self.password, wait=True)
             logger.info(f"[MQ] Connected to ActiveMQ at {self.host}:{self.port} (ssl={self.use_ssl})")

--- a/microservices/pagos/app/infrastructure/messaging/subscriber.py
+++ b/microservices/pagos/app/infrastructure/messaging/subscriber.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import ssl
 import threading
 import stomp
 from datetime import datetime
@@ -167,6 +168,8 @@ class PaymentStatusSubscriber:
                     ssl_options = {'for_hosts': [(self.host, self.port)]}
                     if self.ca_cert_path:
                         ssl_options['ca_certs'] = self.ca_cert_path
+                    else:
+                        ssl_options['cert_reqs'] = ssl.CERT_NONE
                     self._connection.set_ssl(**ssl_options)
                 listener = PaymentStatusListener(
                     app=self.app,

--- a/microservices/reservas/app/infrastructure/messaging/publisher.py
+++ b/microservices/reservas/app/infrastructure/messaging/publisher.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import ssl
 import stomp
 from typing import Optional
 from flask import current_app
@@ -46,6 +47,8 @@ class MessagePublisher:
                 ssl_options = {'for_hosts': [(self.host, self.port)]}
                 if self.ca_cert_path:
                     ssl_options['ca_certs'] = self.ca_cert_path
+                else:
+                    ssl_options['cert_reqs'] = ssl.CERT_NONE
                 self._connection.set_ssl(**ssl_options)
             self._connection.connect(self.username, self.password, wait=True)
             logger.info(f"[MQ] Connected to ActiveMQ at {self.host}:{self.port} (ssl={self.use_ssl})")

--- a/microservices/reservas/app/infrastructure/messaging/subscriber.py
+++ b/microservices/reservas/app/infrastructure/messaging/subscriber.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import ssl
 import threading
 import stomp
 from datetime import datetime
@@ -183,6 +184,8 @@ class PaymentStatusSubscriber:
                     ssl_options = {'for_hosts': [(self.host, self.port)]}
                     if self.ca_cert_path:
                         ssl_options['ca_certs'] = self.ca_cert_path
+                    else:
+                        ssl_options['cert_reqs'] = ssl.CERT_NONE
                     self._connection.set_ssl(**ssl_options)
                 listener = PaymentStatusListener(
                     app=self.app,


### PR DESCRIPTION
This pull request improves the robustness and flexibility of the messaging infrastructure for the `pagos` and `reservas` microservices by enhancing SSL configuration handling. It also updates deployment configuration for internal communication and removes a UI link from the login page.

**Messaging infrastructure improvements:**

* Both publisher and subscriber modules in `pagos` and `reservas` microservices now handle SSL connections more gracefully by setting `cert_reqs=ssl.CERT_NONE` when no CA certificate path is provided, preventing connection failures in environments without CA certs. [[1]](diffhunk://#diff-401a4e80451ae4edb1f685168e69cee362bc8cd76ce6876e32e0133f915065e4R50-R51) [[2]](diffhunk://#diff-5e44208516ef00d0809be67b7126ecd9a7d7392509ac8c91eba3d2db28058be4R171-R172) [[3]](diffhunk://#diff-64bd148d07ee450ced6d0f2fa20784df7a3382915fd1500e81448ab1fe3d9f02R50-R51) [[4]](diffhunk://#diff-5567ecba2620965d5551a0c80359a4351bd6547fe4c18e33e7fddd6e04ae92d6R187-R188)
* Added missing `import ssl` statements in all relevant messaging modules to support the above logic. [[1]](diffhunk://#diff-401a4e80451ae4edb1f685168e69cee362bc8cd76ce6876e32e0133f915065e4R3) [[2]](diffhunk://#diff-5e44208516ef00d0809be67b7126ecd9a7d7392509ac8c91eba3d2db28058be4R3) [[3]](diffhunk://#diff-64bd148d07ee450ced6d0f2fa20784df7a3382915fd1500e81448ab1fe3d9f02R3) [[4]](diffhunk://#diff-5567ecba2620965d5551a0c80359a4351bd6547fe4c18e33e7fddd6e04ae92d6R3)

**Deployment configuration:**

* Updated the `PAGOS_WEBHOOK_URL` in the `pagos` ECS task definition to use the internal ALB DNS and explicit port, ensuring that webhook callbacks are routed internally and not exposed via the public load balancer.

**Frontend/UI:**

* Removed the "Setup Admin" link from the login page, simplifying the UI for end users.…n messaging components