### PR TITLE
sprint 2 despliegue 4

### DIFF
--- a/frontends/web-admin/package.json
+++ b/frontends/web-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-admin",
-  "version": "0.0.0",
+  "version": "0.2.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 4201",

--- a/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.html
+++ b/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.html
@@ -173,13 +173,6 @@
                   t('login.rememberMe')
                 }}</label>
               </div>
-              <div class="text-sm">
-                <a
-                  [routerLink]="['/setup-admin']"
-                  class="font-medium text-primary-600 hover:text-primary-500 transition-colors"
-                  >{{ t('login.setupAdmin') }}</a
-                >
-              </div>
             </div>
 
             <div id="submit-section">

--- a/frontends/web-admin/src/app/features/private/pages/dashboard-page/dashboard-page.component.html
+++ b/frontends/web-admin/src/app/features/private/pages/dashboard-page/dashboard-page.component.html
@@ -386,6 +386,7 @@
       <div class="flex flex-col sm:flex-row justify-between items-center">
         <div class="flex items-center mb-4 sm:mb-0">
           <p class="text-sm text-gray-500">{{ t('footer.copyright') }}</p>
+          <p class="mt-1 text-[10px] leading-none text-gray-400">v0.2.1 · Sprint 2</p>
         </div>
         <div class="flex items-center space-x-6">
           <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors">{{

--- a/frontends/web-client/package.json
+++ b/frontends/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-client",
-  "version": "0.0.0",
+  "version": "0.2.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/frontends/web-client/src/app/shared/components/public-footer/public-footer.component.html
+++ b/frontends/web-client/src/app/shared/components/public-footer/public-footer.component.html
@@ -56,7 +56,7 @@
 
     <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
       <p>{{ t('footer.copyright') }}</p>
-      <p class="mt-2 text-[10px] leading-none text-gray-500">v0.1.0 · Sprint 1</p>
+      <p class="mt-2 text-[10px] leading-none text-gray-500">v0.2.1 · Sprint 2</p>
     </div>
   </div>
 </footer>

--- a/infra/aws/terraform/taskdefs/pagos.json.tpl
+++ b/infra/aws/terraform/taskdefs/pagos.json.tpl
@@ -25,7 +25,7 @@
       "environment": [
         { "name": "FLASK_ENV", "value": "production" },
         { "name": "EXT_PAYMENTS_URL", "value": "http://__PUBLIC_ALB_DNS__/ext-payments" },
-        { "name": "PAGOS_WEBHOOK_URL", "value": "http://__PUBLIC_ALB_DNS__" },
+        { "name": "PAGOS_WEBHOOK_URL", "value": "http://__INTERNAL_ALB_DNS__:5002" },
         { "name": "MQ_HOST", "value": "__MQ_HOST__" },
         { "name": "MQ_PORT", "value": "__MQ_PORT__" },
         { "name": "MQ_USE_SSL", "value": "true" },

--- a/microservices/pagos/app/infrastructure/messaging/publisher.py
+++ b/microservices/pagos/app/infrastructure/messaging/publisher.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import ssl
 import stomp
 from typing import Optional
 from flask import current_app
@@ -46,6 +47,8 @@ class MessagePublisher:
                 ssl_options = {'for_hosts': [(self.host, self.port)]}
                 if self.ca_cert_path:
                     ssl_options['ca_certs'] = self.ca_cert_path
+                else:
+                    ssl_options['cert_reqs'] = ssl.CERT_NONE
                 self._connection.set_ssl(**ssl_options)
             self._connection.connect(self.username, self.password, wait=True)
             logger.info(f"[MQ] Connected to ActiveMQ at {self.host}:{self.port} (ssl={self.use_ssl})")

--- a/microservices/pagos/app/infrastructure/messaging/subscriber.py
+++ b/microservices/pagos/app/infrastructure/messaging/subscriber.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import ssl
 import threading
 import stomp
 from datetime import datetime
@@ -167,6 +168,8 @@ class PaymentStatusSubscriber:
                     ssl_options = {'for_hosts': [(self.host, self.port)]}
                     if self.ca_cert_path:
                         ssl_options['ca_certs'] = self.ca_cert_path
+                    else:
+                        ssl_options['cert_reqs'] = ssl.CERT_NONE
                     self._connection.set_ssl(**ssl_options)
                 listener = PaymentStatusListener(
                     app=self.app,

--- a/microservices/reservas/app/infrastructure/messaging/publisher.py
+++ b/microservices/reservas/app/infrastructure/messaging/publisher.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import ssl
 import stomp
 from typing import Optional
 from flask import current_app
@@ -46,6 +47,8 @@ class MessagePublisher:
                 ssl_options = {'for_hosts': [(self.host, self.port)]}
                 if self.ca_cert_path:
                     ssl_options['ca_certs'] = self.ca_cert_path
+                else:
+                    ssl_options['cert_reqs'] = ssl.CERT_NONE
                 self._connection.set_ssl(**ssl_options)
             self._connection.connect(self.username, self.password, wait=True)
             logger.info(f"[MQ] Connected to ActiveMQ at {self.host}:{self.port} (ssl={self.use_ssl})")

--- a/microservices/reservas/app/infrastructure/messaging/subscriber.py
+++ b/microservices/reservas/app/infrastructure/messaging/subscriber.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import ssl
 import threading
 import stomp
 from datetime import datetime
@@ -183,6 +184,8 @@ class PaymentStatusSubscriber:
                     ssl_options = {'for_hosts': [(self.host, self.port)]}
                     if self.ca_cert_path:
                         ssl_options['ca_certs'] = self.ca_cert_path
+                    else:
+                        ssl_options['cert_reqs'] = ssl.CERT_NONE
                     self._connection.set_ssl(**ssl_options)
                 listener = PaymentStatusListener(
                     app=self.app,


### PR DESCRIPTION
This pull request includes several updates across the web frontends, infrastructure, and microservices to improve versioning, update environment configuration, and enhance message queue SSL handling. The main changes are grouped below.

**Frontend and Versioning Updates:**

* Bumped the version numbers in `package.json` for both `web-admin` and `web-client` to `0.2.1`. [[1]](diffhunk://#diff-4f321b6dec768267621726291c8a1160b814e63b756e96fa34281beae3fab822L3-R3) [[2]](diffhunk://#diff-2af7a43d3e9571b9d82f23c8b12bd90885a11a044258975c7f81a1fc3ca24a37L3-R3)
* Updated the displayed version and sprint info in the footers of both the web admin and web client dashboards. [[1]](diffhunk://#diff-c284df8d682d875a87e6f4d2785d74a79d6af85d4f195923f748d49faf58d583R389) [[2]](diffhunk://#diff-1eb4096aa440ae3503d988672da62c90f6167462ec01a663d34be2dcb35d7ed3L59-R59)
* Removed the "Setup Admin" link from the login page in the web admin frontend.

**Infrastructure Configuration:**

* Changed the `PAGOS_WEBHOOK_URL` in the Pagos task definition to use the internal ALB DNS and port 5002, instead of the public ALB.

**Microservices Message Queue SSL Handling:**

* Updated both `pagos` and `reservas` microservices (publisher and subscriber) to import `ssl` and set `ssl.CERT_NONE` as the default when no CA certificate path is provided, improving flexibility for environments without CA certificates. [[1]](diffhunk://#diff-401a4e80451ae4edb1f685168e69cee362bc8cd76ce6876e32e0133f915065e4R3) [[2]](diffhunk://#diff-401a4e80451ae4edb1f685168e69cee362bc8cd76ce6876e32e0133f915065e4R50-R51) [[3]](diffhunk://#diff-5e44208516ef00d0809be67b7126ecd9a7d7392509ac8c91eba3d2db28058be4R3) [[4]](diffhunk://#diff-5e44208516ef00d0809be67b7126ecd9a7d7392509ac8c91eba3d2db28058be4R171-R172) [[5]](diffhunk://#diff-64bd148d07ee450ced6d0f2fa20784df7a3382915fd1500e81448ab1fe3d9f02R3) [[6]](diffhunk://#diff-64bd148d07ee450ced6d0f2fa20784df7a3382915fd1500e81448ab1fe3d9f02R50-R51) [[7]](diffhunk://#diff-5567ecba2620965d5551a0c80359a4351bd6547fe4c18e33e7fddd6e04ae92d6R3) [[8]](diffhunk://#diff-5567ecba2620965d5551a0c80359a4351bd6547fe4c18e33e7fddd6e04ae92d6R187-R188)