### PR TITLE
feat: invalidate Redis cache after releasing room hold during reserva…

### DIFF
--- a/microservices/reservas/app/api/v1/reservas.py
+++ b/microservices/reservas/app/api/v1/reservas.py
@@ -205,6 +205,15 @@ def _execute_reservation_creation(
     if user_hold:
         release_hold_use_case = ReleaseRoomHoldUseCase(room_hold_repository)
         release_hold_use_case.execute(user_hold.id)
+        # Invalidate Redis cache so the next hold request creates a fresh DB record
+        _lock_svc = get_redis_lock_service()
+        if _lock_svc:
+            _lock_svc.invalidate_room_hold_cache(
+                id_habitacion,
+                fecha_ingreso.strftime('%Y-%m-%d'),
+                fecha_salida.strftime('%Y-%m-%d'),
+                user_hold.id,
+            )
         current_app.logger.info(f"[RESERVAS] Hold {user_hold.id} released after reservation creation")
     
     pagos_service = get_pagos_service()


### PR DESCRIPTION
This pull request adds logic to ensure that the Redis cache for room holds is properly invalidated after a reservation is created, which helps prevent stale data and ensures that subsequent hold requests interact with up-to-date information.

**Cache Invalidation Improvements:**

* Added a call to the Redis lock service to invalidate the room hold cache after releasing a hold, ensuring that future hold requests create a fresh database record. (`microservices/reservas/app/api/v1/reservas.py`)…tion creation