### PR TITLE
sprint 2 despliegue 7

### DIFF
--- a/frontends/web-client/cypress/e2e/inventory-sync.cy.ts
+++ b/frontends/web-client/cypress/e2e/inventory-sync.cy.ts
@@ -66,14 +66,17 @@ describe('Flujo E2E #4: Sincronizacion de inventario (parcial)', () => {
       cy.visit(searchUrl);
       cy.wait('@searchHotelsRequest');
 
-      // Aserciones laxas: a nivel de page no debe aparecer un precio > 0
-      // ni un boton "Reservar ahora" habilitado para este hotel.
+      // Aserciones laxas y RETRYABLES: usamos cy.get(...).should(...) en
+      // lugar de .then() para que Cypress re-ejecute el callback hasta
+      // que la pagina deje de mostrar el loader y pinte el resultado
+      // (sin el should, en maquinas lentas el body aun puede mostrar
+      // "Cargando..." cuando el callback corre la unica vez).
       // Verificamos al menos UNA de estas condiciones:
       //   - Texto "$0" / "0,00" / "0.00" presente
       //   - Texto "sin habitacion" / "no rooms" / "sem quarto"
       //   - Texto "no disponible" / "not available" / "indisponivel"
       //   - O bien el componente app-search-results-empty existe
-      cy.get('body').then(($body) => {
+      cy.get('body').should(($body) => {
         const text = $body.text();
         const hasZeroPrice = /\$\s*0[.,]\s*0{1,2}\b|US\$\s*0\b/i.test(text);
         const hasUnavailable =
@@ -113,43 +116,46 @@ describe('Flujo E2E #4: Sincronizacion de inventario (parcial)', () => {
     it('A.4 una segunda busqueda tras webhook muestra inventario reducido (escenario dinamico)', () => {
       // Simulamos el flujo completo: una primera busqueda devuelve hoteles,
       // luego el PMS dispara un webhook, y una segunda busqueda devuelve
-      // disponibilidad cero. Este escenario es MAS realista que A.2 porque
-      // prueba la transicion, no solo el estado final.
-      let requestCount = 0;
-      cy.intercept('POST', '**/api/v1/hoteles/buscar-disponibles', (req) => {
-        requestCount += 1;
-        req.reply({
-          fixture:
-            requestCount === 1 ? 'search-results.json' : 'search-results-no-availability.json',
+      // disponibilidad cero. Pre-cargamos los fixtures fuera del callback
+      // del intercept para evitar lectura asincrona dentro del handler
+      // (causa potencial de flakiness).
+      cy.fixture('search-results.json').then((fullResults) => {
+        cy.fixture('search-results-no-availability.json').then((emptyResults) => {
+          let requestCount = 0;
+          cy.intercept('POST', '**/api/v1/hoteles/buscar-disponibles', (req) => {
+            requestCount += 1;
+            req.reply(requestCount === 1 ? fullResults : emptyResults);
+          }).as('dynamicSearch');
+
+          // Primera busqueda: backend con inventario
+          cy.visit(searchUrl);
+          cy.wait('@dynamicSearch');
+          cy.get('#hotel-cards app-hotel-result-card').should('have.length.at.least', 1);
+
+          // "El PMS envia un webhook al backend" — simulado cambiando el fixture servido.
+          // Recargar la pagina fuerza una nueva consulta a buscar-disponibles.
+          cy.reload();
+          cy.wait('@dynamicSearch');
+
+          // Ahora la UI debe reflejar la disponibilidad cero. Aceptamos
+          // tres estados validos: card con $0, texto "sin habitacion" o
+          // componente app-search-results-empty. Usamos .should() para
+          // que Cypress re-ejecute el callback hasta que el loader sea
+          // reemplazado por el contenido renderizado.
+          cy.get('body').should(($body) => {
+            const text = $body.text();
+            const hasZeroPrice = /\$\s*0[.,]\s*0{1,2}\b|US\$\s*0\b/i.test(text);
+            const hasUnavailable =
+              /sin habitacion|no rooms|sem quarto|0 habitacion|no disponible|not available|indisponivel/i.test(
+                text,
+              );
+            const emptyComponent = $body.find('app-search-results-empty').length > 0;
+            expect(
+              hasZeroPrice || hasUnavailable || emptyComponent,
+              'la pagina debe indicar de alguna forma que no hay disponibilidad',
+            ).to.be.true;
+          });
         });
-      }).as('dynamicSearch');
-
-      // Primera busqueda: backend con inventario
-      cy.visit(searchUrl);
-      cy.wait('@dynamicSearch');
-      cy.get('#hotel-cards app-hotel-result-card').should('have.length.at.least', 1);
-
-      // "El PMS envia un webhook al backend" — simulado cambiando el fixture servido.
-      // Recargar la pagina fuerza una nueva consulta a buscar-disponibles.
-      cy.reload();
-      cy.wait('@dynamicSearch');
-
-      // Ahora la UI debe reflejar la disponibilidad cero. Dependiendo del
-      // comportamiento del componente, el hotel puede filtrarse o mostrarse
-      // con un estado especial.
-      cy.get('body').then(($body) => {
-        const hotelCards = $body.find('#hotel-cards app-hotel-result-card');
-        if (hotelCards.length > 0) {
-          cy.get('#hotel-cards app-hotel-result-card')
-            .first()
-            .within(() => {
-              cy.contains(
-                /\$\s*0[.,]?0?0?|0\s*rooms?|sin habitacion|sem quarto|no rooms|0 habitacion/i,
-              ).should('exist');
-            });
-        } else {
-          cy.get('app-search-results-empty').should('exist');
-        }
       });
     });
   });

--- a/frontends/web-client/cypress/e2e/reservation-cycle.cy.ts
+++ b/frontends/web-client/cypress/e2e/reservation-cycle.cy.ts
@@ -436,7 +436,11 @@ describe('Flujo E2E #3: Ciclo completo de reserva', () => {
   describe('D. Confirmacion visual y por correo (TFP-15.2)', () => {
     beforeEach(() => {
       // Sprint2: para llegar a la vista de confirmacion hay que completar
-      // el flujo completo (huesped → reserva → pago → polling).
+      // el flujo completo (huesped → reserva → pago → polling → email).
+      // Esperamos explicitamente a @sendEmailJs para asegurar que el envio
+      // ya ocurrio antes de cada test (evita race condition donde el
+      // componente cambia a vista de confirmacion antes de despachar el
+      // email asincrono).
       cy.visit(reservationUrl);
       cy.wait(['@getHotelById', '@getHotelRooms', '@acquireHold']);
       cy.fillReservationForm({ email: 'buyer@test.com' });
@@ -447,6 +451,7 @@ describe('Flujo E2E #3: Ciclo completo de reserva', () => {
       cy.contains('button', /complete payment/i).click();
       cy.wait('@processPayment');
       cy.wait('@getPaymentStatus');
+      cy.wait('@sendEmailJs');
     });
 
     it('D.1 muestra el stepper completo con los 5 pasos en "done"', () => {
@@ -468,8 +473,8 @@ describe('Flujo E2E #3: Ciclo completo de reserva', () => {
     });
 
     it('D.4 el envio del email a EmailJS incluye los datos del huesped y la reserva', () => {
-      // Sprint2 dejo de usar POST /notificaciones (backend) y migro a
-      // EmailJS (servicio externo). Verificamos el payload del intercept.
+      // El beforeEach ya esperó a @sendEmailJs, asi que cy.get retorna
+      // el interception capturado de manera deterministica.
       cy.get('@sendEmailJs').then((interception: any) => {
         const body = interception.request.body;
         expect(body).to.have.property('template_params');

--- a/microservices/reservas/app/api/v1/reservas.py
+++ b/microservices/reservas/app/api/v1/reservas.py
@@ -205,6 +205,15 @@ def _execute_reservation_creation(
     if user_hold:
         release_hold_use_case = ReleaseRoomHoldUseCase(room_hold_repository)
         release_hold_use_case.execute(user_hold.id)
+        # Invalidate Redis cache so the next hold request creates a fresh DB record
+        _lock_svc = get_redis_lock_service()
+        if _lock_svc:
+            _lock_svc.invalidate_room_hold_cache(
+                id_habitacion,
+                fecha_ingreso.strftime('%Y-%m-%d'),
+                fecha_salida.strftime('%Y-%m-%d'),
+                user_hold.id,
+            )
         current_app.logger.info(f"[RESERVAS] Hold {user_hold.id} released after reservation creation")
     
     pagos_service = get_pagos_service()


### PR DESCRIPTION
This pull request primarily improves the reliability and determinism of E2E Cypress tests for inventory synchronization and reservation flows, and adds a cache invalidation step to the reservation creation logic in the backend. The most important changes include making Cypress assertions retryable to avoid flakiness, preloading fixtures to ensure deterministic test data, waiting for email dispatch to prevent race conditions, and invalidating Redis cache after releasing a room hold.

**Cypress E2E Test Improvements:**

* Updated assertions in inventory synchronization tests to use `cy.get(...).should(...)` instead of `.then()`, making them retryable and more robust against loading delays. This reduces flakiness when the page is slow to render results. [[1]](diffhunk://#diff-ccd934c88ba85d07095ab391ceed8d2ebfc8fd85220cbe42c905c2ce753cacbfL69-R79) [[2]](diffhunk://#diff-ccd934c88ba85d07095ab391ceed8d2ebfc8fd85220cbe42c905c2ce753cacbfL137-L152)
* Preloaded fixtures outside of the intercept callback in the dynamic inventory test to avoid asynchronous reads inside the handler, ensuring deterministic test execution.

**Reservation Flow Test Reliability:**

* Added an explicit wait for the `@sendEmailJs` intercept in the reservation cycle test's `beforeEach` hook, ensuring that the email is sent before assertions run and eliminating race conditions. [[1]](diffhunk://#diff-5042161f8ff2f63625042ce8335e5afb0acc79231990bf8c6e00c432b7a17923L439-R443) [[2]](diffhunk://#diff-5042161f8ff2f63625042ce8335e5afb0acc79231990bf8c6e00c432b7a17923R454)
* Updated comments and logic to clarify that the email interception is now deterministic due to the explicit wait.

**Backend Reservation Logic:**

* After releasing a room hold upon reservation creation, now invalidates the corresponding Redis cache entry to ensure subsequent hold requests operate on fresh data.