### PR TITLE
Update AWS CD workflow and local plan to use EmailJS secrets and remo…

### DIFF
--- a/.github/workflows/cd-aws-main.yml
+++ b/.github/workflows/cd-aws-main.yml
@@ -24,9 +24,17 @@ jobs:
       TF_IN_AUTOMATION: true
       TF_VAR_aws_region: us-east-2
       TF_VAR_github_repository: ${{ github.repository }}
+      TF_VAR_emailjs_service_id: ${{ vars.EMAILJS_SERVICE_ID }}
+      TF_VAR_emailjs_public_key: ${{ vars.EMAILJS_PUBLIC_KEY }}
+      TF_VAR_emailjs_private_key: ${{ secrets.EMAILJS_PRIVATE_KEY }}
+      TF_VAR_emailjs_verification_template_id: ${{ vars.EMAILJS_VERIFICATION_TEMPLATE_ID }}
       TF_BACKEND_BUCKET: ${{ vars.TF_BACKEND_BUCKET }}
       TF_BACKEND_KEY: ${{ vars.TF_BACKEND_KEY }}
       TF_BACKEND_DYNAMODB_TABLE: ${{ vars.TF_BACKEND_DYNAMODB_TABLE }}
+      EMAILJS_SERVICE_ID: ${{ vars.EMAILJS_SERVICE_ID }}
+      EMAILJS_PUBLIC_KEY: ${{ vars.EMAILJS_PUBLIC_KEY }}
+      EMAILJS_PRIVATE_KEY: ${{ secrets.EMAILJS_PRIVATE_KEY }}
+      EMAILJS_VERIFICATION_TEMPLATE_ID: ${{ vars.EMAILJS_VERIFICATION_TEMPLATE_ID }}
 
     steps:
       - name: Checkout merged commit
@@ -186,6 +194,8 @@ jobs:
           REDIS_HOST=$(jq -r '.redis_primary_endpoint.value' "$TF_OUTPUTS")
           MQ_HOST=$(jq -r '.mq_host.value' "$TF_OUTPUTS")
           MQ_PORT=$(jq -r '.mq_port.value' "$TF_OUTPUTS")
+          FRONTEND_CORS_ORIGINS=$(jq -r '.frontend_urls.value | to_entries | map(.value) | join(",")' "$TF_OUTPUTS")
+          WEBCLIENT_URL=$(jq -r '.frontend_urls.value["web-client"]' "$TF_OUTPUTS")
 
           reconcile_listener() {
             local service="$1"
@@ -262,6 +272,18 @@ jobs:
             replace_placeholder "__REDIS_HOST__" "$REDIS_HOST"
             replace_placeholder "__MQ_HOST__" "$MQ_HOST"
             replace_placeholder "__MQ_PORT__" "$MQ_PORT"
+            replace_placeholder "__CORS_ORIGINS__" "$FRONTEND_CORS_ORIGINS"
+            replace_placeholder "__WEBCLIENT_URL__" "$WEBCLIENT_URL"
+            replace_placeholder "__EMAILJS_SERVICE_ID__" "${EMAILJS_SERVICE_ID:-}"
+            replace_placeholder "__EMAILJS_PUBLIC_KEY__" "${EMAILJS_PUBLIC_KEY:-}"
+            replace_placeholder "__EMAILJS_PRIVATE_KEY__" "${EMAILJS_PRIVATE_KEY:-}"
+            replace_placeholder "__EMAILJS_TEMPLATE_ID__" "${EMAILJS_VERIFICATION_TEMPLATE_ID:-}"
+
+            if grep -Eq '__[A-Z0-9_]+__' "$output_file"; then
+              echo "Unresolved placeholders detected in ${output_file}"
+              grep -Eo '__[A-Z0-9_]+__' "$output_file" | sort -u
+              exit 1
+            fi
 
             echo "$output_file"
           }

--- a/infra/aws/terraform/local-plan.tfvars
+++ b/infra/aws/terraform/local-plan.tfvars
@@ -2,7 +2,10 @@
 aws_region        = "us-east-2"
 
 # EmailJS — producción
-emailjs_service_id                 = "service_ir1ojbq"
-emailjs_public_key                 = "iqjzNhxcPVbGXAAo4"
-emailjs_private_key                = "YFb9tY4sc0q114bVZpf4E"
-emailjs_verification_template_id   = "template_r0guto8"
+# IMPORTANTE: Valores reales están en GitHub Actions Secrets/Variables, NO aquí.
+# Este archivo está en .gitignore para evitar exponer secretos.
+# Para despliegues locales de Terraform, usa: terraform apply -var-file=local-plan.tfvars
+# emailjs_service_id                 = "REPLACE_WITH_GITHUB_VAR"
+# emailjs_public_key                 = "REPLACE_WITH_GITHUB_VAR"
+# emailjs_private_key                = "REPLACE_WITH_GITHUB_SECRET"
+# emailjs_verification_template_id   = "REPLACE_WITH_GITHUB_VAR"


### PR DESCRIPTION
This pull request updates the deployment workflow to improve the handling of EmailJS configuration and frontend URLs. The changes ensure that sensitive EmailJS credentials are managed securely using GitHub Actions secrets and variables, and that all necessary environment variables are correctly passed to Terraform and application templates. Additionally, the workflow now checks for unresolved placeholders to prevent misconfigurations.

**Deployment workflow improvements:**

* Added EmailJS credentials (`EMAILJS_SERVICE_ID`, `EMAILJS_PUBLIC_KEY`, `EMAILJS_PRIVATE_KEY`, `EMAILJS_VERIFICATION_TEMPLATE_ID`) as environment variables and Terraform variables in `.github/workflows/cd-aws-main.yml`, sourcing them from GitHub Actions secrets and variables for improved security and consistency.
* Updated the template substitution logic to include new placeholders for EmailJS configuration and frontend URLs, and added a check to fail the deployment if any placeholders remain unresolved.

**Frontend configuration enhancements:**

* Extracted `FRONTEND_CORS_ORIGINS` and `WEBCLIENT_URL` from Terraform outputs and made them available for template substitution in the deployment workflow, supporting better frontend-backend integration.

**Infrastructure variable management:**

* Removed hardcoded EmailJS credentials from `infra/aws/terraform/local-plan.tfvars` and added instructions to use GitHub Actions secrets/variables for sensitive values, improving security and maintainability.…ve sensitive data