### PR TITLE
feat: add setup admin button to login page and update imports

### DIFF
--- a/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.html
+++ b/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.html
@@ -190,6 +190,16 @@
               </button>
             </div>
           </form>
+
+          <div id="additional-options" class="mt-6 pt-6 border-t border-gray-100 text-center">
+            <button
+              type="button"
+              routerLink="/setup-admin"
+              class="text-xs text-gray-400 hover:text-primary-600 transition-colors"
+            >
+              {{ t('login.setupAdmin') }}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.ts
+++ b/frontends/web-admin/src/app/features/auth/pages/login-page/login-page.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectorRef, Component, NgZone } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 import { AuthService } from '../../../../core/services/auth.service';
 import { AdminLoginStep1Response } from '../../../../core/models/auth.models';
@@ -11,7 +11,7 @@ import { LanguageCode } from '../../../../core/i18n/translations';
 @Component({
   selector: 'app-login-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
   templateUrl: './login-page.component.html',
 })
 export class LoginPageComponent {


### PR DESCRIPTION
This pull request adds an option for users to navigate to the admin setup page directly from the login page. It also updates the component to support the new routing feature.

Enhancements to the login page:

* Added a button labeled with `login.setupAdmin` that links to the `/setup-admin` route, allowing users to access the admin setup from the login page. (`login-page.component.html`)

Routing and module updates:

* Imported `RouterLink` from `@angular/router` in the `login-page.component.ts` file and added it to the component's `imports` array to enable the new navigation button. [[1]](diffhunk://#diff-3be0fc28fa5336f5975db8274a583e30ab9b5f68e38abb2b863bc3cd55ea6b7aL4-R4) [[2]](diffhunk://#diff-3be0fc28fa5336f5975db8274a583e30ab9b5f68e38abb2b863bc3cd55ea6b7aL14-R14)