### PR TITLE
Fix payment display logic to ensure correct total is shown in reserva…

### DIFF
--- a/frontends/web-admin/src/app/features/private/pages/reservation-detail-page/reservation-detail-page.component.html
+++ b/frontends/web-admin/src/app/features/private/pages/reservation-detail-page/reservation-detail-page.component.html
@@ -406,7 +406,7 @@
                   </div>
                   <div class="text-right">
                     <p class="text-lg font-bold mt-1" [ngClass]="getPaymentAmountClass(p.estado)">
-                      {{ formatCurrency(p.total) }}
+                      {{ formatCurrency(getPaymentDisplayTotal(p)) }}
                     </p>
                     <span
                       class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium mt-1"

--- a/frontends/web-admin/src/app/features/private/pages/reservation-detail-page/reservation-detail-page.component.ts
+++ b/frontends/web-admin/src/app/features/private/pages/reservation-detail-page/reservation-detail-page.component.ts
@@ -252,6 +252,13 @@ export class ReservationDetailPageComponent implements OnInit {
   getTotalPaid(): number {
     const backendTotalPaid = this.detail?.price_breakdown?.total_pagado ?? 0;
     if (backendTotalPaid > 0) {
+      const backendBalance = this.detail?.price_breakdown?.balance_pendiente ?? 0;
+      // When balance is 0 the full amount (including taxes) was paid.
+      // The backend stores only the pre-tax base in total_pagado, so we
+      // return the full calculated total to avoid showing the wrong amount.
+      if (backendBalance === 0) {
+        return this.getCalculatedTotal();
+      }
       return backendTotalPaid;
     }
 
@@ -260,6 +267,20 @@ export class ReservationDetailPageComponent implements OnInit {
 
   getTotalPaidWithTax(): number {
     return Math.round(this.getTotalPaid() * 1.1 * 100) / 100;
+  }
+
+  /**
+   * Returns the display amount for a payment row.
+   * When there is only one payment and the balance is fully settled,
+   * the backend may store only the pre-tax base; we return the full
+   * calculated total (including taxes) so the UI matches what was charged.
+   */
+  getPaymentDisplayTotal(payment: ReservationPaymentItem): number {
+    const balance = this.detail?.price_breakdown?.balance_pendiente ?? -1;
+    if (balance === 0 && this.paymentsToShow.length === 1) {
+      return this.getCalculatedTotal();
+    }
+    return payment.total;
   }
 
   getRemainingBalance(): number {
@@ -459,7 +480,7 @@ export class ReservationDetailPageComponent implements OnInit {
             phone: this.getPlaceholderPhone(),
             guests: String(this.detail.nro_personas),
             nights: String(this.detail.nro_noches ?? 0),
-            totalPaid: this.formatCurrency(this.getTotalPaidWithTax()),
+            totalPaid: this.formatCurrency(this.getTotalPaid()),
             paymentMethod: 'TravelHub',
           };
 
@@ -481,7 +502,7 @@ export class ReservationDetailPageComponent implements OnInit {
           hotelName: this.detail.hotel.nombre,
           checkIn: this.formatDate(this.detail.fecha_ingreso),
           checkOut: this.formatDate(this.detail.fecha_salida),
-          totalRefunded: this.formatCurrency(this.getTotalPaidWithTax()),
+          totalRefunded: this.formatCurrency(this.getTotalPaid()),
           rejectionReason: actionReason || 'No reason provided',
         };
 

--- a/frontends/web-client/src/app/features/search-results/pages/reservation-form-page/reservation-form-page.component.ts
+++ b/frontends/web-client/src/app/features/search-results/pages/reservation-form-page/reservation-form-page.component.ts
@@ -676,7 +676,10 @@ export class ReservationFormPageComponent {
       return '-';
     }
 
-    const parsed = new Date(value);
+    // Append T00:00:00 so the date-only string is parsed as local midnight,
+    // avoiding timezone offset shifting the day backwards (e.g. UTC-5).
+    const localStr = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00` : value;
+    const parsed = new Date(localStr);
     if (Number.isNaN(parsed.getTime())) {
       return value;
     }


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the reservation management and email notification features, focusing on better handling of taxes in reservation displays, more accurate payment information, expanded reservation status handling, and updates to email delivery integration. The most significant changes are summarized below.

### Reservation UI and Payment Calculation Improvements

* Added a "Taxes (10%)" column to the reservations table in the admin UI and updated translations for English, Spanish, and Portuguese to support this new field. [[1]](diffhunk://#diff-2af7a65a3cfcbb15e744a19fbd25c7e0522bb7bf35c2db2787c1c954addccd3fR397-R401) [[2]](diffhunk://#diff-2af7a65a3cfcbb15e744a19fbd25c7e0522bb7bf35c2db2787c1c954addccd3fR469-R473) [[3]](diffhunk://#diff-8bb210944fc830a69e1b14d247b097a8733d9ea2e0ec4e62929d2489feaa0fd9R106) [[4]](diffhunk://#diff-8bb210944fc830a69e1b14d247b097a8733d9ea2e0ec4e62929d2489feaa0fd9R417) [[5]](diffhunk://#diff-8bb210944fc830a69e1b14d247b097a8733d9ea2e0ec4e62929d2489feaa0fd9R729) [[6]](diffhunk://#diff-8bb210944fc830a69e1b14d247b097a8733d9ea2e0ec4e62929d2489feaa0fd9R1044)
* Implemented a new `formatTaxes` function and logic to display taxes per reservation, and updated the payment display logic to ensure the UI shows the full amount paid (including taxes) when the balance is settled. [[1]](diffhunk://#diff-625a030b8e360ff672d6f52e443172faeb5b17c450a3e9e3deab8577fe39715fR198-R204) [[2]](diffhunk://#diff-67b7d4762c5fd5debd8f003f6a1a2a85cc5af8589fabf82915b6efd86d1e127aR255-R285) [[3]](diffhunk://#diff-15602a17e56b80616b4ffa807da898c59a65974361a481dce7b05ab55ee61817L409-R409)
* Updated the guest-facing reservations page to show a "tax included" note and improved button logic for reservation actions based on new statuses. [[1]](diffhunk://#diff-e5291f30a55da7e12fd407e5e4a26401686843671762111343ee33874adc49b7R143-L153) [[2]](diffhunk://#diff-e5291f30a55da7e12fd407e5e4a26401686843671762111343ee33874adc49b7L168-R182)

### Reservation Status Handling

* Expanded reservation status types to include `rejected` and `paymentReceived`, and updated filtering and tab logic to accommodate these new statuses. [[1]](diffhunk://#diff-cdf69f6c9fe866f7aa2a142df9ac96196d698d65a0b010f31d802d2c53adc8f0L21-R27) [[2]](diffhunk://#diff-cdf69f6c9fe866f7aa2a142df9ac96196d698d65a0b010f31d802d2c53adc8f0L80-R91)
* Added translations for the new statuses and the "tax included" label in both English and Spanish. [[1]](diffhunk://#diff-cdf69f6c9fe866f7aa2a142df9ac96196d698d65a0b010f31d802d2c53adc8f0R164-R166) [[2]](diffhunk://#diff-cdf69f6c9fe866f7aa2a142df9ac96196d698d65a0b010f31d802d2c53adc8f0R206-R208) [[3]](diffhunk://#diff-cdf69f6c9fe866f7aa2a142df9ac96196d698d65a0b010f31d802d2c53adc8f0R246-R248)

### Email Delivery Integration

* Added support for sending payment confirmation emails via EmailJS in the web client, including a new template ID and payload structure. [[1]](diffhunk://#diff-87beb010735ba43c035021ed9a906e7c5bf07625533ed049f6b5fe67da2a40d8R8) [[2]](diffhunk://#diff-87beb010735ba43c035021ed9a906e7c5bf07625533ed049f6b5fe67da2a40d8R108-R140)
* Updated environment configuration for EmailJS, including new template IDs and public keys in both production and development environments. [[1]](diffhunk://#diff-9e85505239d9b7411c24d6acffb93fd1c069d06565f691f1008cb6f1af8158ceR4-R12) [[2]](diffhunk://#diff-19a37fa91db54b5dfed974af402776536cb9768d99c7215749b4c58a2bd329e0L10-R11)
* Updated EmailJS private key in both `docker-compose.yml` and `docker-compose-scaled.yml` for backend services. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L184-R184) [[2]](diffhunk://#diff-ddc07981b6047e6a272aee5386b6c10349fa272c854d0d74d6486182df8b1309L232-R232)

### UI Navigation Cleanup

* Removed the "search results" navigation link from both desktop and mobile navigation components in the guest web client. [[1]](diffhunk://#diff-38333025f31a6a273f5357b6e41b6f26820705c5f8465f3e4c6c83c9301b6904L27-R27) [[2]](diffhunk://#diff-933b41f81e294343cf024d3958798a3fb5d13ac8003f8453ec3cc698122de920L15-R15)

### Miscellaneous

* Removed a test line from the `README.md`.