### PR TITLE
Update footer version to v0.3.1 for Sprint 3

### DIFF
--- a/frontends/web-admin/src/app/shared/components/admin-footer/admin-footer.component.html
+++ b/frontends/web-admin/src/app/shared/components/admin-footer/admin-footer.component.html
@@ -3,7 +3,7 @@
     <div class="flex flex-col sm:flex-row justify-between items-center">
       <div class="flex items-center mb-4 sm:mb-0">
         <p class="text-sm text-gray-500">{{ t('footer.copyright') }}</p>
-        <p class="mt-1 text-[10px] leading-none text-gray-400">v0.2.1 · Sprint 2</p>
+        <p class="mt-1 text-[10px] leading-none text-gray-400">v0.3.1 · Sprint 3</p>
       </div>
       <div class="flex items-center space-x-6">
         <a href="#" class="text-sm text-gray-500 hover:text-gray-700 transition-colors">{{

--- a/frontends/web-client/src/app/shared/components/public-footer/public-footer.component.html
+++ b/frontends/web-client/src/app/shared/components/public-footer/public-footer.component.html
@@ -56,7 +56,7 @@
 
     <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
       <p>{{ t('footer.copyright') }}</p>
-      <p class="mt-2 text-[10px] leading-none text-gray-500">v0.2.1 · Sprint 2</p>
+      <p class="mt-2 text-[10px] leading-none text-gray-500">v0.3.1 · Sprint 3</p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
This pull request updates the displayed version and sprint number in the footer components of both the admin and public web clients to reflect the latest release.

UI version updates:

* Updated the version and sprint information from "v0.2.1 · Sprint 2" to "v0.3.1 · Sprint 3" in the `admin-footer.component.html` file.
* Updated the version and sprint information from "v0.2.1 · Sprint 2" to "v0.3.1 · Sprint 3" in the `public-footer.component.html` file.